### PR TITLE
fix: update validators

### DIFF
--- a/backend/typescript/middlewares/validators/authValidators.ts
+++ b/backend/typescript/middlewares/validators/authValidators.ts
@@ -65,9 +65,7 @@ export const registerRequestValidator = async (
         .status(400)
         .send(getApiValidationError("instagramLink", "string"));
     }
-    if (
-      req.body.businessName &&
-      !validatePrimitive(req.body.businessName, "string")
+    if (validatePrimitive(req.body.businessName, "string")
     ) {
       return res
         .status(400)

--- a/backend/typescript/middlewares/validators/authValidators.ts
+++ b/backend/typescript/middlewares/validators/authValidators.ts
@@ -65,8 +65,7 @@ export const registerRequestValidator = async (
         .status(400)
         .send(getApiValidationError("instagramLink", "string"));
     }
-    if (validatePrimitive(req.body.businessName, "string")
-    ) {
+    if (!validatePrimitive(req.body.businessName, "string")) {
       return res
         .status(400)
         .send(getApiValidationError("businessName", "string"));

--- a/backend/typescript/middlewares/validators/donorValidator.ts
+++ b/backend/typescript/middlewares/validators/donorValidator.ts
@@ -6,12 +6,18 @@ const donorDtoValidator = async (
   res: Response,
   next: NextFunction,
 ) => {
-  if (!validatePrimitive(req.body.facebookLink, "string")) {
+  if (
+    req.body.facebookLink &&
+    !validatePrimitive(req.body.facebookLink, "string")
+  ) {
     return res
       .status(400)
       .send(getApiValidationError("facebookLink", "string"));
   }
-  if (!validatePrimitive(req.body.instagramLink, "string")) {
+  if (
+    req.body.instagramLink &&
+    !validatePrimitive(req.body.instagramLink, "string")
+  ) {
     return res
       .status(400)
       .send(getApiValidationError("instagramLink", "string"));


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Before, not having `businessName` in `auth/register` endpoint with donor role ended up creating a user but not donor because `businessName` is a mandatory field. Change in `authAPIValidator` fixes that. Also made `facebookLink` and `instagramLink` optional.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Send post request to `auth/register` endpoint without businessName and request would not go through.
2. Send put request to `donor:id` endpoint without facebookLink and instagramLink and request should go through.



## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
