### PR TITLE
fix: hide password input field and add `businessName` to signup flow

### DIFF
--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -61,12 +61,13 @@ const register = async (
   email: string,
   phoneNumber: string,
   password: string,
+  businessName: string,
   role: string,
 ): Promise<AuthenticatedUser> => {
   try {
     const { data } = await baseAPIClient.post(
       "/auth/register",
-      { firstName, lastName, email, phoneNumber, password, role },
+      { firstName, lastName, email, phoneNumber, password, role, businessName },
       { withCredentials: true },
     );
     localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(data));

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -51,6 +51,7 @@ const Login = (): React.ReactElement => {
               value={password}
               name="password"
               onChange={setValue}
+              type="password"
             />
           </Box>
           <Text mt="1rem" color="hubbard.100" textStyle="mobileSmall">

--- a/frontend/src/components/auth/Signup/AccountDetails.tsx
+++ b/frontend/src/components/auth/Signup/AccountDetails.tsx
@@ -189,6 +189,7 @@ const AccountDetails = ({
           <MandatoryInputDescription label="Confirm password" />
           <Input
             mt="2"
+            type="password"
             value={confirmPassword}
             onChange={setForm}
             name="confirmPassword"

--- a/frontend/src/components/auth/Signup/AccountDetails.tsx
+++ b/frontend/src/components/auth/Signup/AccountDetails.tsx
@@ -48,7 +48,6 @@ const AccountDetails = ({
   setForm: SetForm;
 }) => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
-  const role = "Donor";
   const history = useHistory();
   const { previous } = navigation;
   const {
@@ -57,7 +56,9 @@ const AccountDetails = ({
     email,
     phoneNumber,
     confirmPassword,
+    businessName,
     password,
+    role,
   } = formValues;
   const [showPassword, setShowPassword] = useState(false);
 
@@ -68,6 +69,7 @@ const AccountDetails = ({
       email,
       phoneNumber,
       password,
+      businessName,
       role,
     );
     if (!user) {

--- a/frontend/src/components/auth/Signup/index.tsx
+++ b/frontend/src/components/auth/Signup/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavigationProps, Step, useForm, useStep } from "react-hooks-helper";
 
+import { Role } from "../../../types/AuthTypes";
 import AccountDetails from "./AccountDetails";
 import CreateAccount from "./CreateAccount";
 
@@ -25,7 +26,7 @@ const Signup = () => {
     password: "",
     confirmPassword: "",
     businessName: "",
-    role: "Donor",
+    role: Role.DONOR,
   });
 
   const { step, navigation }: UseStepType = useStep({ steps, initialStep: 0 });

--- a/frontend/src/components/auth/Signup/index.tsx
+++ b/frontend/src/components/auth/Signup/index.tsx
@@ -25,6 +25,7 @@ const Signup = () => {
     password: "",
     confirmPassword: "",
     businessName: "",
+    role: "Donor",
   });
 
   const { step, navigation }: UseStepType = useStep({ steps, initialStep: 0 });

--- a/frontend/src/components/auth/Signup/types.ts
+++ b/frontend/src/components/auth/Signup/types.ts
@@ -6,4 +6,5 @@ export interface SignUpFormProps {
   password: string;
   confirmPassword: string;
   businessName: string;
+  role: string;
 }

--- a/frontend/src/types/AuthTypes.ts
+++ b/frontend/src/types/AuthTypes.ts
@@ -1,9 +1,16 @@
+export enum Role {
+  USER = "User",
+  ADMIN = "Admin",
+  VOLUNTEER = "Volunteer",
+  DONOR = "Donor",
+}
+
 export type AuthenticatedUser = {
   id: string;
   firstName: string;
   lastName: string;
   email: string;
-  role: "Admin" | "User" | "Donor" | "Volunteer";
+  role: Role;
   accessToken: string;
   phoneNumber: string;
 } | null;
@@ -13,7 +20,7 @@ export type AuthenticatedDonor = {
   firstName: string;
   lastName: string;
   email: string;
-  role: "Donor";
+  role: Role.DONOR;
   phoneNumber: string;
   accessToken: string;
   businessName: string;


### PR DESCRIPTION
Closes: 

[Add businessName to sign up flow](https://www.notion.so/uwblueprintexecs/Fix-Registering-a-User-dd7a2800b1724e5282be338f26d2f19d)
[Hide Password input](https://www.notion.so/uwblueprintexecs/Hide-Password-Field-in-Authentication-ce74bd4e373740b98a7491cc842b9bad)

![image](https://user-images.githubusercontent.com/19617248/142746227-a7bb4cbd-80e3-4dc4-b8cb-382a323412a5.png)

**To verify:**

If adding all inputs in the signup flow returns success. 
