### PR TITLE
fix: update landing page copy

### DIFF
--- a/frontend/src/components/pages/Home/DonationProcess.tsx
+++ b/frontend/src/components/pages/Home/DonationProcess.tsx
@@ -49,17 +49,17 @@ const DonationProcess = (): JSX.Element => {
       <DonationStep
         stepNumber={1}
         title="Create an account"
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut condimentum libero. Cras sodales."
+        description="Join us as a donor on our donation platform."
       />
       <DonationStep
         stepNumber={2}
         title="Schedule a dropoff"
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut condimentum libero. Cras sodales."
+        description="Use the donor platform to schedule your donations to the community fridge."
       />
       <DonationStep
         stepNumber={3}
         title="Complete your donation"
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut condimentum libero. Cras sodales."
+        description="Complete your donation and feel good about redistributing food in our community."
       />
       <Button width="100%" variant="navigation">
         Start now

--- a/frontend/src/components/pages/Home/VolunteerRoles.tsx
+++ b/frontend/src/components/pages/Home/VolunteerRoles.tsx
@@ -41,12 +41,12 @@ const VolunteerRoles = () => (
       Volunteer Roles
     </Text>
     <VolunteerRoleStep
-      title="Assist with a dropoff"
-      description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut condimentum libero. Cras sodales."
+      title="Sign up for a fridge check-in"
+      description="Visit the fridge in your desired time window to complete one of the three daily fridge check-ins to maintain public health standards."
     />
     <VolunteerRoleStep
-      title="Conduct a check-in"
-      description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut condimentum libero. Cras sodales."
+      title="Assist with food rescue"
+      description="Support a donation from a local business, organization or individual by making a pick-up or assisting with donation unloading and stocking at the fridge."
     />
   </Container>
 );


### PR DESCRIPTION
Update landing page copy with correct wording (remove filler text)
<img width="410" alt="Screen Shot 2021-12-01 at 1 11 42 PM" src="https://user-images.githubusercontent.com/19617248/144289974-6fb6cbda-89bb-49a5-963a-0bb3e565ddb5.png">

