### PR TITLE
fix: Update scheduling get started page

### DIFF
--- a/frontend/src/components/pages/Scheduling/GetStarted.tsx
+++ b/frontend/src/components/pages/Scheduling/GetStarted.tsx
@@ -27,7 +27,7 @@ const GetStarted = ({ navigation }: SchedulingStepProps) => {
         marginBottom="50px"
         width="100%"
       />
-      <Button onClick={next} variant="navigation">
+      <Button onClick={next} variant="navigation" w="100%">
         Get started
       </Button>
     </Container>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Scheduling Flow - Update image and spacing](https://www.notion.so/uwblueprintexecs/Scheduling-flow-Update-get-started-image-and-spacing-8b1f390e86564b31baf923a7a3cd74ca)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated Get Started image and made button spacing 100% width


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Scheduling Get Started page should look like: 

<img width="159" alt="Screen Shot 2021-12-02 at 4 59 06 PM" src="https://user-images.githubusercontent.com/37950626/144509905-68154526-7727-49f1-9383-dc04bc201c21.png">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
