### PR TITLE
style: fix homepage button and styling bugs

### DIFF
--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -70,7 +70,7 @@ const Account = (): JSX.Element => {
             />
           </Box>
           <Text
-            mt={{ base: "2rem", md: "3rem" }}
+            mt={{ base: "40px", md: "54px" }}
             mb="1em"
             textStyle="mobileBodyBold"
             color="hubbard.100"
@@ -105,7 +105,7 @@ const Account = (): JSX.Element => {
               />
             </Box>
           </HStack>
-          <Box mt={{ base: "2rem", md: "3rem" }}>
+          <Box mt={{ base: "24px", md: "40px" }}>
             <Text>Phone number</Text>
             <Input
               mt="2"
@@ -119,7 +119,7 @@ const Account = (): JSX.Element => {
               fontWeight="500"
             />
           </Box>
-          <Box mt={{ base: "2rem", md: "3rem" }}>
+          <Box mt={{ base: "24px", md: "40px" }}>
             <Text>Email address</Text>
             <Input
               mt="2"
@@ -132,8 +132,14 @@ const Account = (): JSX.Element => {
               fontWeight="500"
             />
           </Box>
-          <Box mt={{ base: "2rem", md: "3rem" }}>
-            <Button mt="2" variant="navigation" onClick={navigateToDashboard}>
+          <Box mt={{ base: "66px", md: "56px" }}>
+            <Button
+              width="100%"
+              size="lg"
+              mt="2"
+              variant="navigation"
+              onClick={navigateToDashboard}
+            >
               View Scheduled Donations
             </Button>
           </Box>

--- a/frontend/src/components/pages/Home/DonationProcess.tsx
+++ b/frontend/src/components/pages/Home/DonationProcess.tsx
@@ -1,5 +1,9 @@
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
-import React from "react";
+import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
+
+import AuthContext from "../../../contexts/AuthContext";
+import * as Routes from "../../../constants/Routes";
 
 interface DonationStepProps {
   title: string;
@@ -44,6 +48,9 @@ const DonationStep = ({
 };
 
 const DonationProcess = (): JSX.Element => {
+  const history = useHistory();
+  const { authenticatedUser } = useContext(AuthContext);
+
   return (
     <Box mt="57px">
       <Text color="hubbard.100" textStyle="mobilePretitleBold" mb="1rem">
@@ -70,7 +77,16 @@ const DonationProcess = (): JSX.Element => {
         />
       </Flex>
 
-      <Button width="100%" variant="navigation" display={{ md: "none" }}>
+      <Button
+        width="100%"
+        variant="navigation"
+        display={{ md: "none" }}
+        onClick={() =>
+          history.push(
+            authenticatedUser ? Routes.SCHEDULING_PAGE : Routes.LOGIN_PAGE,
+          )
+        }
+      >
         Start now
       </Button>
     </Box>

--- a/frontend/src/components/pages/Home/DonationProcess.tsx
+++ b/frontend/src/components/pages/Home/DonationProcess.tsx
@@ -80,6 +80,7 @@ const DonationProcess = (): JSX.Element => {
       <Button
         width="100%"
         variant="navigation"
+        size="lg"
         display={{ md: "none" }}
         onClick={() =>
           history.push(

--- a/frontend/src/components/pages/Home/DonationProcess.tsx
+++ b/frontend/src/components/pages/Home/DonationProcess.tsx
@@ -2,8 +2,8 @@ import { Box, Button, Flex, Text } from "@chakra-ui/react";
 import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 
-import AuthContext from "../../../contexts/AuthContext";
 import * as Routes from "../../../constants/Routes";
+import AuthContext from "../../../contexts/AuthContext";
 
 interface DonationStepProps {
   title: string;
@@ -18,7 +18,7 @@ const DonationStep = ({
   return (
     <Flex
       paddingBottom="1.5rem"
-      px="1.2rem"
+      px={{ base: "0px", md: "1.2rem" }}
       textAlign={{ md: "center" }}
       width="100%"
     >
@@ -59,7 +59,7 @@ const DonationProcess = (): JSX.Element => {
       <Text mb="1.5rem" color="black.100" textStyle="mobileHeader2">
         The Donation Process
       </Text>
-      <Flex direction={{ base: "column", md: "row" }} padding="30px">
+      <Flex direction={{ base: "column", md: "row" }}>
         <DonationStep
           stepNumber={1}
           title="Create an account"

--- a/frontend/src/components/pages/Home/index.tsx
+++ b/frontend/src/components/pages/Home/index.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, Container, Flex, Image, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Container,
+  Divider,
+  Flex,
+  Image,
+  Text,
+} from "@chakra-ui/react";
 import React from "react";
 import { useHistory } from "react-router-dom";
 
@@ -15,7 +23,7 @@ const Home = (): JSX.Element => {
       <Container
         maxWidth={{ base: "default", md: "70%" }}
         px={{ base: "42px", md: "0px" }}
-        pt="73px"
+        pt={{ base: "55px", md: "121px" }}
       >
         <Image
           src="drawer-logo.png"
@@ -34,13 +42,13 @@ const Home = (): JSX.Element => {
 
             <Text marginBottom="30px" textStyle="mobileBody">
               Community fridges are public repositories of fresh, donated foods
-              that anyone can take from for free.
+              that anyone can take from for free. Community fridges are public
+              repositories of fresh, donated foods.
             </Text>
             <Button
               size="lg"
               onClick={() => history.push(SCHEDULING_PAGE)}
               variant="navigation"
-              width="100%"
             >
               Schedule a food dropoff
             </Button>
@@ -59,6 +67,11 @@ const Home = (): JSX.Element => {
         <Box maxWidth={{ base: "default", md: "70%" }} marginLeft="-7.5rem">
           {/* TODO: Add back after styling fix <ViewDonations isPublicView /> */}
         </Box>
+        <Divider
+          color="hubbard.100"
+          mt={{ base: "0px", md: "40px" }}
+          opacity={{ base: "0%", md: "100%" }}
+        />
         <DonationProcess />
         <VolunteerRoles />
       </Container>

--- a/frontend/src/components/pages/Home/index.tsx
+++ b/frontend/src/components/pages/Home/index.tsx
@@ -40,6 +40,7 @@ const Home = (): JSX.Element => {
               size="lg"
               onClick={() => history.push(SCHEDULING_PAGE)}
               variant="navigation"
+              width="100%"
             >
               Schedule a food dropoff
             </Button>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Homepage Missing Start Now Button](https://www.notion.so/uwblueprintexecs/Homepage-Missing-Start-Now-Button-dd1cacacf1cf4f80bf8f8caf551c2071)
[Homepage Styling
](https://www.notion.so/uwblueprintexecs/Homepage-Styling-fbd389a9c1ed44a5838e80df92262595)[My Account Page Styling](https://www.notion.so/uwblueprintexecs/My-Account-Page-Spacing-37986db6d7ac430fa7353b24b681f599)

### Change Details
* make buttons on home page full width w/ same padding
* navigate start now button depending on user authentication status
* fix misc padding and stylings