### PR TITLE
feat: backend add delete recurring donations API endpoint

### DIFF
--- a/backend/typescript/rest/schedulingRoutes.ts
+++ b/backend/typescript/rest/schedulingRoutes.ts
@@ -129,10 +129,10 @@ schedulingRouter.delete("/:id?", async (req, res) => {
   if (recurringDonationId) {
     try {
       await schedulingService.deleteSchedulingByRecurringDonationId(
-        recurringDonationId as string
+        recurringDonationId as string,
       );
       res.status(204).send();
-    } catch(error: unknown) {
+    } catch (error: unknown) {
       res.status(500).json({ error: getErrorMessage(error) });
     }
   } else if (id) {

--- a/backend/typescript/rest/schedulingRoutes.ts
+++ b/backend/typescript/rest/schedulingRoutes.ts
@@ -119,10 +119,23 @@ schedulingRouter.put("/:id", updateSchedulingDtoValidator, async (req, res) => {
   }
 });
 
-/* Delete scheduling by id */
-schedulingRouter.delete("/:id", async (req, res) => {
+/* Delete scheduling by id (e.g. /scheduling/63)
+  and takes optional query for recurring donation 
+  id to delete by recurring donations (e.g. /scheduling/63?recurringDonationId=1)
+*/
+schedulingRouter.delete("/:id?", async (req, res) => {
   const { id } = req.params;
-  if (id) {
+  const { recurringDonationId } = req.query;
+  if (recurringDonationId) {
+    try {
+      await schedulingService.deleteSchedulingByRecurringDonationId(
+        recurringDonationId as string
+      );
+      res.status(204).send();
+    } catch(error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  } else if (id) {
     try {
       await schedulingService.deleteSchedulingById(id);
       res.status(204).send();

--- a/backend/typescript/services/implementations/__tests__/schedulingService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/schedulingService.test.ts
@@ -93,6 +93,17 @@ const testSchedules = [
   },
 ];
 
+const schedules = testSchedules.map((schedule) => {
+  const scheduleSnakeCase: Record<
+    string,
+    string | string[] | boolean | number | Date | undefined
+  > = {};
+  Object.entries(schedule).forEach(([key, value]) => {
+    scheduleSnakeCase[snakeCase(key)] = value;
+  });
+  return scheduleSnakeCase;
+});
+
 describe("pg schedulingService", () => {
   let schedulingService: SchedulingService;
 
@@ -109,17 +120,6 @@ describe("pg schedulingService", () => {
   });
 
   test("getSchedules", async () => {
-    const schedules = testSchedules.map((schedule) => {
-      const scheduleSnakeCase: Record<
-        string,
-        string | string[] | boolean | number | Date | undefined
-      > = {};
-      Object.entries(schedule).forEach(([key, value]) => {
-        scheduleSnakeCase[snakeCase(key)] = value;
-      });
-      return scheduleSnakeCase;
-    });
-
     await Scheduling.bulkCreate(schedules);
 
     const res = await schedulingService.getSchedulings();
@@ -128,17 +128,6 @@ describe("pg schedulingService", () => {
   });
 
   test("getSchedulesByDonorId", async () => {
-    const schedules = testSchedules.map((schedule) => {
-      const scheduleSnakeCase: Record<
-        string,
-        string | string[] | boolean | number | Date | undefined
-      > = {};
-      Object.entries(schedule).forEach(([key, value]) => {
-        scheduleSnakeCase[snakeCase(key)] = value;
-      });
-      return scheduleSnakeCase;
-    });
-
     await Scheduling.bulkCreate(schedules);
     const { donorId } = testSchedules[0];
     const res = await schedulingService.getSchedulingsByDonorId(
@@ -151,17 +140,6 @@ describe("pg schedulingService", () => {
   });
 
   test("getScheduleById", async () => {
-    const schedules = testSchedules.map((schedule) => {
-      const scheduleSnakeCase: Record<
-        string,
-        string | string[] | boolean | number | Date | undefined
-      > = {};
-      Object.entries(schedule).forEach(([key, value]) => {
-        scheduleSnakeCase[snakeCase(key)] = value;
-      });
-      return scheduleSnakeCase;
-    });
-
     await Scheduling.bulkCreate(schedules);
     const res = await schedulingService.getSchedulingById("1");
     expect(res).toMatchObject(testSchedules[0]);
@@ -359,17 +337,6 @@ describe("pg schedulingService", () => {
   });
 
   test("updateScheduling", async () => {
-    const schedules = testSchedules.map((schedule) => {
-      const scheduleSnakeCase: Record<
-        string,
-        string | string[] | boolean | number | Date | undefined
-      > = {};
-      Object.entries(schedule).forEach(([key, value]) => {
-        scheduleSnakeCase[snakeCase(key)] = value;
-      });
-      return scheduleSnakeCase;
-    });
-
     await Scheduling.bulkCreate(schedules);
 
     // Updating one of each type of field
@@ -393,17 +360,6 @@ describe("pg schedulingService", () => {
   });
 
   test("deleteScheduling", async () => {
-    const schedules = testSchedules.map((schedule) => {
-      const scheduleSnakeCase: Record<
-        string,
-        string | string[] | boolean | number | Date | undefined
-      > = {};
-      Object.entries(schedule).forEach(([key, value]) => {
-        scheduleSnakeCase[snakeCase(key)] = value;
-      });
-      return scheduleSnakeCase;
-    });
-
     await Scheduling.bulkCreate(schedules);
 
     const schedulingToDelete: Scheduling | null = await Scheduling.findOne();
@@ -421,17 +377,6 @@ describe("pg schedulingService", () => {
   });
 
   test("deleteRecurringScheduling", async () => {
-    const schedules = testSchedules.map((schedule) => {
-      const scheduleSnakeCase: Record<
-        string,
-        string | string[] | boolean | number | Date | undefined
-      > = {};
-      Object.entries(schedule).forEach(([key, value]) => {
-        scheduleSnakeCase[snakeCase(key)] = value;
-      });
-      return scheduleSnakeCase;
-    });
-
     await Scheduling.bulkCreate(schedules);
 
     const recurringIdCount = schedules.filter((schedule) => schedule.recurring_donation_id === RECURRING_DONATION_ID).length;

--- a/backend/typescript/services/implementations/__tests__/schedulingService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/schedulingService.test.ts
@@ -379,15 +379,19 @@ describe("pg schedulingService", () => {
   test("deleteRecurringScheduling", async () => {
     await Scheduling.bulkCreate(schedules);
 
-    const recurringIdCount = schedules.filter((schedule) => schedule.recurring_donation_id === RECURRING_DONATION_ID).length;
+    const recurringIdCount = schedules.filter(
+      (schedule) => schedule.recurring_donation_id === RECURRING_DONATION_ID,
+    ).length;
 
     const res = await schedulingService.deleteSchedulingByRecurringDonationId(
-      RECURRING_DONATION_ID
+      RECURRING_DONATION_ID,
     );
     const schedulingsDbAfterDelete: Scheduling[] = await Scheduling.findAll();
     schedulingsDbAfterDelete.forEach((scheduling: Scheduling) => {
       expect(scheduling.recurring_donation_id).not.toBe(RECURRING_DONATION_ID);
     });
-    expect(schedulingsDbAfterDelete.length).toBe(testSchedules.length - recurringIdCount);
+    expect(schedulingsDbAfterDelete.length).toBe(
+      testSchedules.length - recurringIdCount,
+    );
   });
 });

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -437,6 +437,26 @@ class SchedulingService implements ISchedulingService {
       throw error;
     }
   }
+
+  async deleteSchedulingByRecurringDonationId(
+    recurring_donation_id: string): Promise<void> {
+      console.log(Scheduling);
+    try {
+      const numsDestroyed = await Scheduling.destroy({
+        where: { recurring_donation_id: recurring_donation_id},
+      });
+      if (numsDestroyed <= 0) {
+        throw new Error(
+          `scheduling with recurring_donation_id ${recurring_donation_id} was not deleted.`,
+        );
+      }
+    } catch (error) {
+      Logger.error(
+        `Failed to delete scheduling. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
 }
 
 export default SchedulingService;

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -440,7 +440,6 @@ class SchedulingService implements ISchedulingService {
 
   async deleteSchedulingByRecurringDonationId(
     recurring_donation_id: string): Promise<void> {
-      console.log(Scheduling);
     try {
       const numsDestroyed = await Scheduling.destroy({
         where: { recurring_donation_id: recurring_donation_id},

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -439,10 +439,11 @@ class SchedulingService implements ISchedulingService {
   }
 
   async deleteSchedulingByRecurringDonationId(
-    recurring_donation_id: string): Promise<void> {
+    recurring_donation_id: string,
+  ): Promise<void> {
     try {
       const numsDestroyed = await Scheduling.destroy({
-        where: { recurring_donation_id: recurring_donation_id},
+        where: { recurring_donation_id },
       });
       if (numsDestroyed <= 0) {
         throw new Error(

--- a/backend/typescript/services/interfaces/schedulingService.ts
+++ b/backend/typescript/services/interfaces/schedulingService.ts
@@ -64,7 +64,9 @@ interface ISchedulingService {
    * @param reucrring_donation_id recurring donation id
    * @throws Error if recurring donation deletion fails
    */
-  deleteSchedulingByRecurringDonationId(recurring_donation_id: string): Promise<void>;
+  deleteSchedulingByRecurringDonationId(
+    recurring_donation_id: string,
+  ): Promise<void>;
 }
 
 export default ISchedulingService;

--- a/backend/typescript/services/interfaces/schedulingService.ts
+++ b/backend/typescript/services/interfaces/schedulingService.ts
@@ -58,6 +58,13 @@ interface ISchedulingService {
    * @throws Error if scheduling deletion fails
    */
   deleteSchedulingById(id: string): Promise<void>;
+
+  /**
+   * Delete a scheduling by recurring_donation_id
+   * @param reucrring_donation_id recurring donation id
+   * @throws Error if recurring donation deletion fails
+   */
+  deleteSchedulingByRecurringDonationId(recurring_donation_id: string): Promise<void>;
 }
 
 export default ISchedulingService;


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Backend-Delete-Recurring-Donations](https://www.notion.so/uwblueprintexecs/Backend-Delete-Recurring-Donations-075290dbb8e340b58ad46d9244ff8213)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* All recurring donations have a ```recurring_donation_id``` (one-time donations have this as ```null```). If we want to delete the recurring donation, we will call upon the preexisting DELETE API endpoint but allow an optional parameter at ```DELETE scheduling/:id?recurringDonationId=1```

e.g. if the donation we are deleting has id: 63 and recurringDonationId: 1 we test the endpoint at
```scheduling/63?recurrringDonationId=1```
* I also deleted some unnecessary testing code that was repeated? Ideally I think a lot of the test constants should be in its own separate file but not sure what the general thoughts are here (mostly to avoid hundreds of lines of testing code in one file).

![Backend recurring donations demo](http://g.recordit.co/gOh2vZ0RDa.gif)

<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Ensure that you can delete recurring donations at the appropriate endpoint (create a recurring donation and remember the recurring_donation_id - you can also console.log this)
2. Ensure that all ```schedulingService``` tests pass




## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [X] The appropriate tests if necessary have been written
