### PR TITLE
fix: dashboard empty state and donation details updates from visual enhancements

### DIFF
--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -45,6 +45,10 @@ const Dashboard = (): JSX.Element => {
     return <Spinner />;
   }
 
+  const date = new Date();  // 2009-11-10
+  const month = date.toLocaleString('default', { month: 'long' })   
+  const year = date.getFullYear();
+
   return (
     <Container variant="dashboardContainer">
       <Stack direction={["column", "row"]} justifyContent="space-between">

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -5,6 +5,7 @@ import {
   Spinner,
   Stack,
   Text,
+  Flex,
   VStack,
 } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
@@ -102,10 +103,6 @@ const Dashboard = (): JSX.Element => {
               </Text>
             </Box>
           </Flex>
-          // <Text as="i" pt="0.8rem" textStyle="mobileBody" mb="1.5rem">
-            // You currently have no upcoming donations scheduled for the next two
-            // weeks.
-          // </Text>
         )}
       </Box>
     </Container>

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -2,10 +2,14 @@ import {
   Box,
   Button,
   Container,
+  Flex,
   Spinner,
   Stack,
   Text,
+<<<<<<< HEAD
   Flex,
+=======
+>>>>>>> b38d96a (linting)
   VStack,
 } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
@@ -45,8 +49,8 @@ const Dashboard = (): JSX.Element => {
     return <Spinner />;
   }
 
-  const date = new Date();  // 2009-11-10
-  const month = date.toLocaleString('default', { month: 'long' })   
+  const date = new Date(); // 2009-11-10
+  const month = date.toLocaleString("default", { month: "long" });
   const year = date.getFullYear();
 
   return (
@@ -126,7 +130,7 @@ const Dashboard = (): JSX.Element => {
             ))
           ) : (
             <Box>
-              <Box 
+              <Box
                 display={{ lg: "flex" }}
                 flexWrap="wrap"
                 backgroundColor="squash.100"
@@ -146,12 +150,11 @@ const Dashboard = (): JSX.Element => {
                   color="black.500"
                   textStyle="mobileBody"
                 >
-                  Schedule a donation today to start giving back. 
+                  Schedule a donation today to start giving back.
                 </Text>
               </Box>
               <Box>{}</Box>
-   
-              </Box>
+            </Box>
           )}
         </Box>
 >>>>>>> d5371af (changed text spacing again)

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -71,6 +71,7 @@ const Dashboard = (): JSX.Element => {
           Schedule new donation
         </Button>
       </Stack>
+<<<<<<< HEAD
       <Box
         display={{ lg: "flex" }}
         flexDirection="row"
@@ -108,6 +109,52 @@ const Dashboard = (): JSX.Element => {
             </Box>
           </Flex>
         )}
+=======
+      <Text mt="4rem" textStyle="mobileHeader2" pb="0px">
+        {`${month} ${year}`}
+      </Text>
+      <Box display={{ lg: "flex" }} flexDirection="row" flexWrap="wrap">
+        <Box
+          display={{ lg: "flex" }}
+          flexDirection="row"
+          flexWrap="wrap"
+          marginTop={["60px", "70px"]}
+        >
+          {schedules.length > 0 ? (
+            schedules.map((scheduleObject: Schedule, id) => (
+              <DropoffCard key={id} schedule={scheduleObject!} />
+            ))
+          ) : (
+            <Box>
+              <Box 
+                display={{ lg: "flex" }}
+                flexWrap="wrap"
+                backgroundColor="squash.100"
+                padding={{ base: "0px", md: "3rem" }}
+              >
+                <Text
+                  p={{ base: "28px", md: "0px" }}
+                  color="black.500"
+                  textStyle="mobileBody"
+                >
+                  You currently have no upcoming donations scheduled! &nbsp;
+                </Text>
+                <Text
+                  pl={{ base: "28px", md: "0px" }}
+                  pr={{ base: "28px", md: "0px" }}
+                  pb={{ base: "28px", md: "0px" }}
+                  color="black.500"
+                  textStyle="mobileBody"
+                >
+                  Schedule a donation today to start giving back. 
+                </Text>
+              </Box>
+              <Box>{}</Box>
+   
+              </Box>
+          )}
+        </Box>
+>>>>>>> d5371af (changed text spacing again)
       </Box>
     </Container>
   );

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -77,10 +77,35 @@ const Dashboard = (): JSX.Element => {
             <DropoffCard key={id} schedule={scheduleObject!} />
           ))
         ) : (
-          <Text as="i" pt="0.8rem" textStyle="mobileBody" mb="1.5rem">
-            You currently have no upcoming donations scheduled for the next two
-            weeks.
-          </Text>
+          <Flex paddingTop="1.5rem" >
+            <Box 
+              display={{ lg: "flex"}} 
+              width={{ base: "default", md: "100%" }}
+              backgroundColor="squash.100"
+              padding={{ base: "0px", md: "3rem" }}
+            >
+              <Text
+                p={{ base: "28px", md: "0px" }}
+                color="black.500"
+                textStyle="mobileBody"
+              >
+                You currently have no upcoming donations scheduled! &nbsp;
+              </Text>
+              <Text
+                pl={{ base: "28px", md: "0px" }}
+                pr={{ base: "28px", md: "0px" }}
+                pb={{ base: "28px", md: "0px" }}
+                color="black.500"
+                textStyle="mobileBody"
+              >
+                Schedule a donation today to start giving back. 
+              </Text>
+            </Box>
+          </Flex>
+          // <Text as="i" pt="0.8rem" textStyle="mobileBody" mb="1.5rem">
+            // You currently have no upcoming donations scheduled for the next two
+            // weeks.
+          // </Text>
         )}
       </Box>
     </Container>

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -6,10 +6,6 @@ import {
   Spinner,
   Stack,
   Text,
-<<<<<<< HEAD
-  Flex,
-=======
->>>>>>> b38d96a (linting)
   VStack,
 } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
@@ -75,7 +71,6 @@ const Dashboard = (): JSX.Element => {
           Schedule new donation
         </Button>
       </Stack>
-<<<<<<< HEAD
       <Box
         display={{ lg: "flex" }}
         flexDirection="row"
@@ -87,9 +82,9 @@ const Dashboard = (): JSX.Element => {
             <DropoffCard key={id} schedule={scheduleObject!} />
           ))
         ) : (
-          <Flex paddingTop="1.5rem" >
-            <Box 
-              display={{ lg: "flex"}} 
+          <Flex paddingTop="1.5rem">
+            <Box
+              display={{ lg: "flex" }}
               width={{ base: "default", md: "100%" }}
               backgroundColor="squash.100"
               padding={{ base: "0px", md: "3rem" }}
@@ -108,56 +103,11 @@ const Dashboard = (): JSX.Element => {
                 color="black.500"
                 textStyle="mobileBody"
               >
-                Schedule a donation today to start giving back. 
+                Schedule a donation today to start giving back.
               </Text>
             </Box>
           </Flex>
         )}
-=======
-      <Text mt="4rem" textStyle="mobileHeader2" pb="0px">
-        {`${month} ${year}`}
-      </Text>
-      <Box display={{ lg: "flex" }} flexDirection="row" flexWrap="wrap">
-        <Box
-          display={{ lg: "flex" }}
-          flexDirection="row"
-          flexWrap="wrap"
-          marginTop={["60px", "70px"]}
-        >
-          {schedules.length > 0 ? (
-            schedules.map((scheduleObject: Schedule, id) => (
-              <DropoffCard key={id} schedule={scheduleObject!} />
-            ))
-          ) : (
-            <Box>
-              <Box
-                display={{ lg: "flex" }}
-                flexWrap="wrap"
-                backgroundColor="squash.100"
-                padding={{ base: "0px", md: "3rem" }}
-              >
-                <Text
-                  p={{ base: "28px", md: "0px" }}
-                  color="black.500"
-                  textStyle="mobileBody"
-                >
-                  You currently have no upcoming donations scheduled! &nbsp;
-                </Text>
-                <Text
-                  pl={{ base: "28px", md: "0px" }}
-                  pr={{ base: "28px", md: "0px" }}
-                  pb={{ base: "28px", md: "0px" }}
-                  color="black.500"
-                  textStyle="mobileBody"
-                >
-                  Schedule a donation today to start giving back.
-                </Text>
-              </Box>
-              <Box>{}</Box>
-            </Box>
-          )}
-        </Box>
->>>>>>> d5371af (changed text spacing again)
       </Box>
     </Container>
   );

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -94,8 +94,7 @@ const Dashboard = (): JSX.Element => {
               </Text>
               <Text
                 pl={{ base: "28px", md: "0px" }}
-                pr={{ base: "28px", md: "0px" }}
-                pb={{ base: "28px", md: "0px" }}
+                px={{ base: "28px", md: "0px" }}
                 color="black.500"
                 textStyle="mobileBody"
               >

--- a/frontend/src/components/pages/Dashboard/index.tsx
+++ b/frontend/src/components/pages/Dashboard/index.tsx
@@ -45,10 +45,6 @@ const Dashboard = (): JSX.Element => {
     return <Spinner />;
   }
 
-  const date = new Date(); // 2009-11-10
-  const month = date.toLocaleString("default", { month: "long" });
-  const year = date.getFullYear();
-
   return (
     <Container variant="dashboardContainer">
       <Stack direction={["column", "row"]} justifyContent="space-between">

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -40,6 +40,12 @@ const ConfirmDetails = ({
     next();
   };
 
+  const onDeleteClick = async () => {
+    await SchedulingAPIClient.deleteSchedule(currentSchedule.id);
+    history.push(`${Routes.DASHBOARD_PAGE}`);
+    
+  }
+
   const getDonorData = async () => {
     const donorResponse = await DonorAPIClient.getDonorByUserId(
       authenticatedUser!.id,
@@ -51,6 +57,7 @@ const ConfirmDetails = ({
   useEffect(() => {
     getDonorData();
   }, [currentSchedule.id]);
+  
   return (
     <Container variant="responsiveContainer">
       {isBeingEdited ? (
@@ -194,7 +201,7 @@ const ConfirmDetails = ({
           size="lg"
           width={{ lg: "30%", base: "100%" }}
           variant="deleteDonation"
-          onClick={() => history.push(Routes.SCHEDULING_PAGE)}
+          onClick={onDeleteClick}
         >
         Cancel donation
         </Button>

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -98,7 +98,6 @@ const ConfirmDetails = ({
         flexDirection="row-reverse"
       >
         <Button
-          rightIcon={<EditIcon />}
           pl="0"
           variant="ghost"
           color="hubbard.100"
@@ -128,7 +127,6 @@ const ConfirmDetails = ({
         flexDirection="row-reverse"
       >
         <Button
-          rightIcon={<EditIcon />}
           pl="0"
           variant="ghost"
           color="hubbard.100"
@@ -154,7 +152,6 @@ const ConfirmDetails = ({
         flexDirection="row-reverse"
       >
         <Button
-          rightIcon={<EditIcon />}
           pl="0"
           variant="ghost"
           color="hubbard.100"

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -1,16 +1,14 @@
-import { ArrowBackIcon, EditIcon } from "@chakra-ui/icons";
+import { ArrowBackIcon } from "@chakra-ui/icons";
 import {
   Badge,
   Box,
   Button,
   Container,
-  Flex,
   HStack,
   IconButton,
-  Stack,
   Text,
 } from "@chakra-ui/react";
-import { add, format, isBefore, isToday, isTomorrow } from "date-fns";
+import { add, format, isBefore } from "date-fns";
 import React, { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 
@@ -21,7 +19,7 @@ import * as Routes from "../../../constants/Routes";
 import AuthContext from "../../../contexts/AuthContext";
 import { DonorResponse } from "../../../types/DonorTypes";
 import SchedulingProgressBar from "../../common/SchedulingProgressBar";
-import { SchedulingStepProps } from "./types";
+import { DonationFrequency, DonationSizes, SchedulingStepProps } from "./types";
 
 const ConfirmDetails = ({
   formValues,
@@ -37,6 +35,9 @@ const ConfirmDetails = ({
     {} as DonorResponse,
   );
   const currentSchedule = formValues;
+  const { description } = DonationSizes.filter(
+    (category) => category.size === currentSchedule.size,
+  )[0];
 
   const onSubmitClick = async () => {
     await SchedulingAPIClient.createSchedule(currentSchedule);
@@ -68,16 +69,16 @@ const ConfirmDetails = ({
     return format(startDate, "MMMM d, yyyy");
   };
 
-  const nextDateText = (startDate: Date) => {
+  const nextDropoffDateText = (startDate: Date) => {
     let addOptions = {};
     switch (currentSchedule.frequency) {
-      case "Weekly":
+      case DonationFrequency.WEEKLY:
         addOptions = { weeks: 1 };
         break;
-      case "Daily":
+      case DonationFrequency.DAILY:
         addOptions = { days: 1 };
         break;
-      case "Monthly":
+      case DonationFrequency.MONTHLY:
         addOptions = { months: 1 };
         break;
       default:
@@ -117,10 +118,8 @@ const ConfirmDetails = ({
         &nbsp;&nbsp;&nbsp;
         <Badge
           borderRadius="11px"
-          pl="18px"
-          pr="18px"
-          pt="-5px"
-          pb="-5px"
+          px="18px"
+          py="-5px"
           ml={{ md: "5px" }}
           color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
           backgroundColor={`${
@@ -167,19 +166,21 @@ const ConfirmDetails = ({
               {currentSchedule.frequency}
             </Text>
             <Text>
-              {currentSchedule.frequency === "Weekly"
+              {currentSchedule.frequency === DonationFrequency.WEEKLY
                 ? ` on ${dayText(startDateLocal)}s`
                 : ""}
             </Text>
           </HStack>
 
-          {nextDateText(startDateLocal) !== null ||
-          currentSchedule.frequency !== "One time" ? (
+          {nextDropoffDateText(startDateLocal) !== null ||
+          currentSchedule.frequency !== DonationFrequency.ONE_TIME ? (
             <Box>
               <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
                 Next Drop-Off
               </Text>
-              <Text textStyle="mobileBody">{nextDateText(startDateLocal)}</Text>
+              <Text textStyle="mobileBody">
+                {nextDropoffDateText(startDateLocal)}
+              </Text>
               <Text textStyle="mobileBody">
                 {`${startTimeLocal} - ${endTimeLocal}`}
               </Text>{" "}
@@ -209,7 +210,7 @@ const ConfirmDetails = ({
           <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
             Size
           </Text>
-          <Text textStyle="mobileBody">{currentSchedule.size}</Text>
+          <Text textStyle="mobileBody">{`${currentSchedule.size} - ${description}`}</Text>
           <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
             Item Category
           </Text>

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -184,9 +184,13 @@ const ConfirmDetails = ({
               <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text> 
              </Box>
           )}
-          
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Additional notes</Text>
-          <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
+          {(currentSchedule.notes !== "") && (
+            <Box>
+              <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Additional notes</Text>
+            <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
+            </Box>
+          )}
+
         </Box>
       </Box>
 

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -184,6 +184,22 @@ const ConfirmDetails = ({
         <Text textStyle="mobileBody">{currentDonor.phoneNumber}</Text>
         <Text textStyle="mobileBody">{currentDonor.businessName}</Text>
       </Box>
+      <Box m="3em 0" pl="0" align="left">
+        <Text textStyle="mobileHeader2">Danger Zone</Text>
+        <Text textStyle="mobileBody">
+          To cancel this schedule donation, click below.
+        </Text>
+        <Button
+          mt="1.5rem"
+          size="lg"
+          width={{ lg: "30%", base: "100%" }}
+          variant="deleteDonation"
+          onClick={() => history.push(Routes.SCHEDULING_PAGE)}
+        >
+        Cancel donation
+        </Button>
+
+      </Box>
       {!isBeingEdited && (
         <HStack>
           <Button

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -4,15 +4,15 @@ import {
   Box,
   Button,
   Container,
+  Flex,
   HStack,
   IconButton,
-  Text,
   Stack,
-  Flex,
+  Text,
 } from "@chakra-ui/react";
+import { add, format, isBefore, isToday, isTomorrow } from "date-fns";
 import React, { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { format, isToday, isTomorrow, add, isBefore} from "date-fns";
 
 import DonorAPIClient from "../../../APIClients/DonorAPIClient";
 import SchedulingAPIClient from "../../../APIClients/SchedulingAPIClient";
@@ -46,8 +46,7 @@ const ConfirmDetails = ({
   const onDeleteClick = async () => {
     await SchedulingAPIClient.deleteSchedule(currentSchedule.id);
     history.push(`${Routes.DASHBOARD_PAGE}`);
-    
-  }
+  };
 
   const getDonorData = async () => {
     const donorResponse = await DonorAPIClient.getDonorByUserId(
@@ -61,38 +60,38 @@ const ConfirmDetails = ({
   const endDateLocal = new Date(currentSchedule.recurringDonationEndDate);
   const startTimeLocal = format(new Date(currentSchedule.startTime), "K:mm aa");
   const endTimeLocal = format(new Date(currentSchedule.endTime), "K:mm aa");
-  
+
   const dayText = (startDate: Date) => {
     return format(startDate, "eeee");
-  }
+  };
   const dateText = (startDate: Date) => {
     return format(startDate, "MMMM d, yyyy");
-  }
+  };
 
   const nextDateText = (startDate: Date) => {
     let addOptions = {};
-    switch(currentSchedule.frequency) {
+    switch (currentSchedule.frequency) {
       case "Weekly":
-        addOptions = {weeks: 1,}
+        addOptions = { weeks: 1 };
         break;
       case "Daily":
-        addOptions = {days: 1,}
+        addOptions = { days: 1 };
         break;
       case "Monthly":
-        addOptions = {months: 1,}
+        addOptions = { months: 1 };
         break;
-      default: break;
+      default:
+        break;
     }
     const result = add(startDate, addOptions);
     if (!isBefore(result, endDateLocal)) return null;
     return dateText(result);
-
-  }
+  };
 
   useEffect(() => {
     getDonorData();
   }, [currentSchedule.id]);
-  
+
   return (
     <Container variant="responsiveContainer">
       {isBeingEdited ? (
@@ -107,22 +106,30 @@ const ConfirmDetails = ({
       ) : (
         <SchedulingProgressBar activeStep={3} totalSteps={4} />
       )}
-        <Text textStyle="mobileHeader2" mt="1em" direction="row" display={{ md: "flex" }} mb="1em" > 
-          {isBeingEdited? "Donation Details": "Confirm Donation Details"}
-          &nbsp;&nbsp;&nbsp;
-          <Badge
-            borderRadius="11px"
-            pl="18px"
-            pr="18px"
-            pt="-5px"
-            pb="-5px"
-            ml={{md: "5px"}}
-            color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
-            backgroundColor={`${(colorMap as any)[currentSchedule?.frequency]}.50`}
-          >   
+      <Text
+        textStyle="mobileHeader2"
+        mt="1em"
+        direction="row"
+        display={{ md: "flex" }}
+        mb="1em"
+      >
+        {isBeingEdited ? "Donation Details" : "Confirm Donation Details"}
+        &nbsp;&nbsp;&nbsp;
+        <Badge
+          borderRadius="11px"
+          pl="18px"
+          pr="18px"
+          pt="-5px"
+          pb="-5px"
+          ml={{ md: "5px" }}
+          color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
+          backgroundColor={`${
+            (colorMap as any)[currentSchedule?.frequency]
+          }.50`}
+        >
           {currentSchedule?.frequency}
-          </Badge>
-        </Text>
+        </Badge>
+      </Text>
       <Box
         pl="0"
         align="left"
@@ -142,28 +149,42 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader3">Drop-off Information</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Proposed Drop-off Time</Text>
-          <Text textStyle="mobileBody">
-            {dateText(startDateLocal)}
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+            Proposed Drop-off Time
           </Text>
+          <Text textStyle="mobileBody">{dateText(startDateLocal)}</Text>
           <Text textStyle="mobileBody">
             {`${startTimeLocal} - ${endTimeLocal}`}
           </Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Frequency</Text>
-          <HStack spacing='4px'>
-          <Text textStyle="mobileBodyBold" color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}>{currentSchedule.frequency}</Text>
-          <Text>{currentSchedule.frequency==="Weekly"? ` on ${dayText(startDateLocal)}s`: '' }</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+            Frequency
+          </Text>
+          <HStack spacing="4px">
+            <Text
+              textStyle="mobileBodyBold"
+              color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
+            >
+              {currentSchedule.frequency}
+            </Text>
+            <Text>
+              {currentSchedule.frequency === "Weekly"
+                ? ` on ${dayText(startDateLocal)}s`
+                : ""}
+            </Text>
           </HStack>
 
-          {nextDateText(startDateLocal) !== null || currentSchedule.frequency !== "One time"? (
+          {nextDateText(startDateLocal) !== null ||
+          currentSchedule.frequency !== "One time" ? (
             <Box>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Next Drop-Off</Text>
-          <Text textStyle="mobileBody">
-            {nextDateText(startDateLocal)}
-          </Text>
-          <Text textStyle="mobileBody">
-            {`${startTimeLocal} - ${endTimeLocal}`}
-          </Text> </Box>): null}
+              <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+                Next Drop-Off
+              </Text>
+              <Text textStyle="mobileBody">{nextDateText(startDateLocal)}</Text>
+              <Text textStyle="mobileBody">
+                {`${startTimeLocal} - ${endTimeLocal}`}
+              </Text>{" "}
+            </Box>
+          ) : null}
         </Box>
       </Box>
 
@@ -185,9 +206,13 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader3">Donation Information</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Size</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+            Size
+          </Text>
           <Text textStyle="mobileBody">{currentSchedule.size}</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Item Category</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+            Item Category
+          </Text>
           <Text textStyle="mobileBody">
             {currentSchedule.categories.join(", ")}
           </Text>
@@ -212,55 +237,78 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader3">Volunteer Information</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Volunteer Needed</Text>
-          <Text textStyle="mobileBody">{currentSchedule.volunteerNeeded? "Yes": "No"}</Text>
-          <Text textStyle="mobileSmall"color="hubbard.100" pt="1.4em">Pickup Needed</Text>
-          <Text textStyle="mobileBody">{currentSchedule.isPickup? "Yes": "No"}</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+            Volunteer Needed
+          </Text>
+          <Text textStyle="mobileBody">
+            {currentSchedule.volunteerNeeded ? "Yes" : "No"}
+          </Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+            Pickup Needed
+          </Text>
+          <Text textStyle="mobileBody">
+            {currentSchedule.isPickup ? "Yes" : "No"}
+          </Text>
 
-          
           {currentSchedule.isPickup && (
-            <Box> 
-              <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Address</Text>
-              <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text> 
-             </Box>
+            <Box>
+              <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+                Address
+              </Text>
+              <Text textStyle="mobileBody">
+                {currentSchedule.pickupLocation}
+              </Text>
+            </Box>
           )}
           <Box>
-            <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Additional notes</Text>
+            <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+              Additional notes
+            </Text>
             <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
           </Box>
         </Box>
       </Box>
 
       <Box m="3em 0" pl="0" align="left">
-        <Text textStyle="mobileHeader3" >Donor Information</Text>
-        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Name</Text>
+        <Text textStyle="mobileHeader3">Donor Information</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+          Name
+        </Text>
         <Text textStyle="mobileBody">
           {currentDonor.firstName} {currentDonor.lastName}
         </Text>
-        <Text textStyle="mobileSmall"color="hubbard.100" pt="1.4em">Email</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+          Email
+        </Text>
         <Text textStyle="mobileBody">{currentDonor.email}</Text>
-        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Phone</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+          Phone
+        </Text>
         <Text textStyle="mobileBody">{currentDonor.phoneNumber}</Text>
-        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Organization</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+          Organization
+        </Text>
         <Text textStyle="mobileBody">{currentDonor.businessName}</Text>
       </Box>
       {isBeingEdited && (
         <Box m="3em 0" pl="0" align="left">
-        <Text textStyle="mobileHeader3" pb="0.8em">Danger Zone</Text>
-        <Text textStyle="mobileBody">
-          To cancel this schedule donation, click below.
-        </Text>
-        <Button
-          mt="1.5rem"
-          size="lg"
-          width={{ lg: "30%", base: "100%" }}
-          variant="deleteDonation"
-          onClick={onDeleteClick}
-        >
-        Cancel donation
-        </Button>
-      </Box>
-      )}   
+          <Text textStyle="mobileHeader3" pb="0.8em">
+            Danger Zone
+          </Text>
+          <Text textStyle="mobileBody">
+            To cancel this schedule donation, click below.
+          </Text>
+          <Button
+            mt="1.5rem"
+            size="lg"
+            width={{ lg: "30%", base: "100%" }}
+            variant="deleteDonation"
+            onClick={onDeleteClick}
+          >
+            Cancel donation
+          </Button>
+        </Box>
+      )}
       {!isBeingEdited && (
         <HStack>
           <Button

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -113,8 +113,8 @@ const ConfirmDetails = ({
           Edit
         </Button>
         <Box>
-          <Text textStyle="mobileHeader2">Drop-off Information</Text>
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Proposed drop-off time</Text>
+          <Text textStyle="mobileHeader3">Drop-off Information</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Proposed drop-off time</Text>
           <Text textStyle="mobileBody">
             {new Date(currentSchedule.startTime).toDateString()}
           </Text>
@@ -122,7 +122,7 @@ const ConfirmDetails = ({
             {new Date(currentSchedule.startTime).toLocaleTimeString()}-
             {new Date(currentSchedule.endTime).toLocaleTimeString()}
           </Text>
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Frequency</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Frequency</Text>
           <Text textStyle="mobileBodyBold" color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}>{currentSchedule.frequency}</Text>
         </Box>
       </Box>
@@ -144,10 +144,10 @@ const ConfirmDetails = ({
           Edit
         </Button>
         <Box>
-          <Text textStyle="mobileHeader2">Donation Information</Text>
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Size</Text>
+          <Text textStyle="mobileHeader3">Donation Information</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Size</Text>
           <Text textStyle="mobileBody">{currentSchedule.size}</Text>
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Item Category</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Item Category</Text>
           <Text textStyle="mobileBody">
             {currentSchedule.categories.join(", ")}
           </Text>
@@ -171,41 +171,41 @@ const ConfirmDetails = ({
           Edit
         </Button>
         <Box>
-          <Text textStyle="mobileHeader2">Volunteer Information</Text>
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Volunteer Needed</Text>
+          <Text textStyle="mobileHeader3">Volunteer Information</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Volunteer Needed</Text>
           <Text textStyle="mobileBody">{currentSchedule.volunteerNeeded? "Yes": "No"}</Text>
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Pickup Needed</Text>
+          <Text textStyle="mobileSmall"color="hubbard.100" pt="1em">Pickup Needed</Text>
           <Text textStyle="mobileBody">{currentSchedule.isPickup? "Yes": "No"}</Text>
 
           
           {currentSchedule.isPickup && (
             <Box> 
-              <Text textstyle="mobilePretitleBold" color="hubbard.100">Address</Text>
+              <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Address</Text>
               <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text> 
              </Box>
           )}
           
-          <Text textstyle="mobilePretitleBold" color="hubbard.100">Additional notes</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Additional notes</Text>
           <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
         </Box>
       </Box>
 
       <Box m="3em 0" pl="0" align="left">
-        <Text textStyle="mobileHeader2">Donor Information</Text>
-        <Text textstyle="mobilePretitleBold" color="hubbard.100">Name</Text>
+        <Text textStyle="mobileHeader3" >Donor Information</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Name</Text>
         <Text textStyle="mobileBody">
           {currentDonor.firstName} {currentDonor.lastName}
         </Text>
-        <Text textstyle="mobilePretitleBold" color="hubbard.100">Email</Text>
+        <Text textStyle="mobileSmall"color="hubbard.100" pt="1em">Email</Text>
         <Text textStyle="mobileBody">{currentDonor.email}</Text>
-        <Text textstyle="mobilePretitleBold" color="hubbard.100">Phone</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Phone</Text>
         <Text textStyle="mobileBody">{currentDonor.phoneNumber}</Text>
-        <Text textstyle="mobilePretitleBold" color="hubbard.100">Organization</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Organization</Text>
         <Text textStyle="mobileBody">{currentDonor.businessName}</Text>
       </Box>
       {isBeingEdited && (
         <Box m="3em 0" pl="0" align="left">
-        <Text textStyle="mobileHeader2">Danger Zone</Text>
+        <Text textStyle="mobileHeader3" pb="0.8em">Danger Zone</Text>
         <Text textStyle="mobileBody">
           To cancel this schedule donation, click below.
         </Text>

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -78,7 +78,7 @@ const ConfirmDetails = ({
         </Text>
       ) : (
         <Text textStyle="mobileHeader2" mt="2em">
-          Schedule a donation dropoff
+          Confirm Donation Details
         </Text>
       )}
 
@@ -113,7 +113,8 @@ const ConfirmDetails = ({
           Edit
         </Button>
         <Box>
-          <Text textStyle="mobileHeader2">Proposed dropoff time</Text>
+          <Text textStyle="mobileHeader2">Drop-off Information</Text>
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Proposed drop-off time</Text>
           <Text textStyle="mobileBody">
             {new Date(currentSchedule.startTime).toDateString()}
           </Text>
@@ -121,7 +122,8 @@ const ConfirmDetails = ({
             {new Date(currentSchedule.startTime).toLocaleTimeString()}-
             {new Date(currentSchedule.endTime).toLocaleTimeString()}
           </Text>
-          <Text textStyle="mobileBody">{currentSchedule.frequency}</Text>
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Frequency</Text>
+          <Text textStyle="mobileBodyBold" color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}>{currentSchedule.frequency}</Text>
         </Box>
       </Box>
 
@@ -143,7 +145,9 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader2">Donation Information</Text>
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Size</Text>
           <Text textStyle="mobileBody">{currentSchedule.size}</Text>
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Item Category</Text>
           <Text textStyle="mobileBody">
             {currentSchedule.categories.join(", ")}
           </Text>
@@ -168,30 +172,39 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader2">Volunteer Information</Text>
-          {currentSchedule.volunteerNeeded && (
-            <Text textStyle="mobileBody">Volunteer required</Text>
-          )}
-          {currentSchedule.isPickup && (
-            <Text textStyle="mobileBody">Pickup required</Text>
-          )}
-          <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text>
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Volunteer Needed</Text>
+          <Text textStyle="mobileBody">{currentSchedule.volunteerNeeded? "Yes": "No"}</Text>
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Pickup Needed</Text>
+          <Text textStyle="mobileBody">{currentSchedule.isPickup? "Yes": "No"}</Text>
 
-          <Text textStyle="mobileBody">
-            Additional notes: {currentSchedule.notes}
-          </Text>
+          
+          {currentSchedule.isPickup && (
+            <Box> 
+              <Text textstyle="mobilePretitleBold" color="hubbard.100">Address</Text>
+              <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text> 
+             </Box>
+          )}
+          
+          <Text textstyle="mobilePretitleBold" color="hubbard.100">Additional notes</Text>
+          <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
         </Box>
       </Box>
 
       <Box m="3em 0" pl="0" align="left">
-        <Text textStyle="mobileHeader2">Donor information</Text>
+        <Text textStyle="mobileHeader2">Donor Information</Text>
+        <Text textstyle="mobilePretitleBold" color="hubbard.100">Name</Text>
         <Text textStyle="mobileBody">
           {currentDonor.firstName} {currentDonor.lastName}
         </Text>
+        <Text textstyle="mobilePretitleBold" color="hubbard.100">Email</Text>
         <Text textStyle="mobileBody">{currentDonor.email}</Text>
+        <Text textstyle="mobilePretitleBold" color="hubbard.100">Phone</Text>
         <Text textStyle="mobileBody">{currentDonor.phoneNumber}</Text>
+        <Text textstyle="mobilePretitleBold" color="hubbard.100">Organization</Text>
         <Text textStyle="mobileBody">{currentDonor.businessName}</Text>
       </Box>
-      <Box m="3em 0" pl="0" align="left">
+      {isBeingEdited && (
+        <Box m="3em 0" pl="0" align="left">
         <Text textStyle="mobileHeader2">Danger Zone</Text>
         <Text textStyle="mobileBody">
           To cancel this schedule donation, click below.
@@ -205,8 +218,8 @@ const ConfirmDetails = ({
         >
         Cancel donation
         </Button>
-
       </Box>
+      )}   
       {!isBeingEdited && (
         <HStack>
           <Button

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -7,6 +7,7 @@ import {
   HStack,
   IconButton,
   Text,
+  Stack,
 } from "@chakra-ui/react";
 import React, { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
@@ -72,29 +73,23 @@ const ConfirmDetails = ({
       ) : (
         <SchedulingProgressBar activeStep={3} totalSteps={4} />
       )}
-      {isBeingEdited ? (
-        <Text textStyle="mobileHeader1" mt="2em">
-          Donation Details
-        </Text>
-      ) : (
-        <Text textStyle="mobileHeader2" mt="2em">
-          Confirm Donation Details
-        </Text>
-      )}
 
-      <Badge
-        borderRadius="full"
-        pt="6px"
-        pb="6px"
-        pl="14px"
-        pr="14px"
-        mt="12px"
-        color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
-        backgroundColor={`${(colorMap as any)[currentSchedule?.frequency]}.50`}
-      >
-        {currentSchedule?.frequency}
-      </Badge>
-
+        
+        <Text textStyle="mobileHeader1" mt="1em" direction="row" display={{ md: "flex" }}> 
+          {isBeingEdited? "Donation Details": "Confirm Donation Details"}
+          <Badge
+            borderRadius="12px"
+            pl="18px"
+            pr="18px"
+            pt="-5px"
+            pb="-5px"
+            ml={{sm: "2em"}}
+            color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
+            backgroundColor={`${(colorMap as any)[currentSchedule?.frequency]}.50`}
+          >   
+          {currentSchedule?.frequency}
+          </Badge>
+        </Text>
       <Box
         pl="0"
         align="left"

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -184,13 +184,10 @@ const ConfirmDetails = ({
               <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text> 
              </Box>
           )}
-          {(currentSchedule.notes !== "") && (
-            <Box>
-              <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Additional notes</Text>
+          <Box>
+            <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Additional notes</Text>
             <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
-            </Box>
-          )}
-
+          </Box>
         </Box>
       </Box>
 

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -107,15 +107,16 @@ const ConfirmDetails = ({
       ) : (
         <SchedulingProgressBar activeStep={3} totalSteps={4} />
       )}
-        <Text textStyle="mobileHeader1" mt="1em" direction="row" display={{ md: "flex" }}> 
+        <Text textStyle="mobileHeader2" mt="1em" direction="row" display={{ md: "flex" }} mb="1em" > 
           {isBeingEdited? "Donation Details": "Confirm Donation Details"}
+          &nbsp;&nbsp;&nbsp;
           <Badge
             borderRadius="11px"
             pl="18px"
             pr="18px"
             pt="-5px"
             pb="-5px"
-            ml={{sm: "2em"}}
+            ml={{md: "5px"}}
             color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}
             backgroundColor={`${(colorMap as any)[currentSchedule?.frequency]}.50`}
           >   
@@ -141,14 +142,14 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader3">Drop-off Information</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Proposed Drop-off Time</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Proposed Drop-off Time</Text>
           <Text textStyle="mobileBody">
             {dateText(startDateLocal)}
           </Text>
           <Text textStyle="mobileBody">
             {`${startTimeLocal} - ${endTimeLocal}`}
           </Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Frequency</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Frequency</Text>
           <HStack spacing='4px'>
           <Text textStyle="mobileBodyBold" color={`${(colorMap as any)[currentSchedule?.frequency]}.100`}>{currentSchedule.frequency}</Text>
           <Text>{currentSchedule.frequency==="Weekly"? ` on ${dayText(startDateLocal)}s`: '' }</Text>
@@ -156,9 +157,12 @@ const ConfirmDetails = ({
 
           {nextDateText(startDateLocal) !== null || currentSchedule.frequency !== "One time"? (
             <Box>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Next Drop-Off</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Next Drop-Off</Text>
           <Text textStyle="mobileBody">
             {nextDateText(startDateLocal)}
+          </Text>
+          <Text textStyle="mobileBody">
+            {`${startTimeLocal} - ${endTimeLocal}`}
           </Text> </Box>): null}
         </Box>
       </Box>
@@ -181,9 +185,9 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader3">Donation Information</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Size</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Size</Text>
           <Text textStyle="mobileBody">{currentSchedule.size}</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Item Category</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Item Category</Text>
           <Text textStyle="mobileBody">
             {currentSchedule.categories.join(", ")}
           </Text>
@@ -208,20 +212,20 @@ const ConfirmDetails = ({
         </Button>
         <Box>
           <Text textStyle="mobileHeader3">Volunteer Information</Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Volunteer Needed</Text>
+          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Volunteer Needed</Text>
           <Text textStyle="mobileBody">{currentSchedule.volunteerNeeded? "Yes": "No"}</Text>
-          <Text textStyle="mobileSmall"color="hubbard.100" pt="1em">Pickup Needed</Text>
+          <Text textStyle="mobileSmall"color="hubbard.100" pt="1.4em">Pickup Needed</Text>
           <Text textStyle="mobileBody">{currentSchedule.isPickup? "Yes": "No"}</Text>
 
           
           {currentSchedule.isPickup && (
             <Box> 
-              <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Address</Text>
+              <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Address</Text>
               <Text textStyle="mobileBody">{currentSchedule.pickupLocation}</Text> 
              </Box>
           )}
           <Box>
-            <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Additional notes</Text>
+            <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Additional notes</Text>
             <Text textStyle="mobileBody">{currentSchedule.notes}</Text>
           </Box>
         </Box>
@@ -229,15 +233,15 @@ const ConfirmDetails = ({
 
       <Box m="3em 0" pl="0" align="left">
         <Text textStyle="mobileHeader3" >Donor Information</Text>
-        <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Name</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Name</Text>
         <Text textStyle="mobileBody">
           {currentDonor.firstName} {currentDonor.lastName}
         </Text>
-        <Text textStyle="mobileSmall"color="hubbard.100" pt="1em">Email</Text>
+        <Text textStyle="mobileSmall"color="hubbard.100" pt="1.4em">Email</Text>
         <Text textStyle="mobileBody">{currentDonor.email}</Text>
-        <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Phone</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Phone</Text>
         <Text textStyle="mobileBody">{currentDonor.phoneNumber}</Text>
-        <Text textStyle="mobileSmall" color="hubbard.100" pt="1em">Organization</Text>
+        <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">Organization</Text>
         <Text textStyle="mobileBody">{currentDonor.businessName}</Text>
       </Box>
       {isBeingEdited && (

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -100,13 +100,13 @@ const ConfirmDetails = ({
         align="left"
         mt="2rem"
         mb="2rem"
-        display={{ lg: "flex" }}
+        display={{ sm: "flex" }}
         justifyContent="space-between"
         flexDirection="row-reverse"
       >
         <Button
           pl="0"
-          variant="ghost"
+          variant="edit"
           color="hubbard.100"
           onClick={() => go && go("date and time")}
         >
@@ -131,13 +131,13 @@ const ConfirmDetails = ({
         pl="0"
         align="left"
         mb="2rem"
-        display={{ lg: "flex" }}
+        display={{ sm: "flex" }}
         justifyContent="space-between"
         flexDirection="row-reverse"
       >
         <Button
           pl="0"
-          variant="ghost"
+          variant="edit"
           color="hubbard.100"
           onClick={() => go && go("donation information")}
         >
@@ -158,13 +158,13 @@ const ConfirmDetails = ({
         pl="0"
         align="left"
         mb="2rem"
-        display={{ lg: "flex" }}
+        display={{ sm: "flex" }}
         justifyContent="space-between"
         flexDirection="row-reverse"
       >
         <Button
           pl="0"
-          variant="ghost"
+          variant="edit"
           color="hubbard.100"
           onClick={() => go && go("volunteer information")}
         >

--- a/frontend/src/components/pages/Scheduling/DonationInformation.tsx
+++ b/frontend/src/components/pages/Scheduling/DonationInformation.tsx
@@ -13,15 +13,11 @@ import {
 import React, { ChangeEvent, useState } from "react";
 
 import SchedulingAPIClient from "../../../APIClients/SchedulingAPIClient";
-import xl from "../../../assets/donation-sizes/lg.png";
-import lg from "../../../assets/donation-sizes/md.png";
-import md from "../../../assets/donation-sizes/sm.png";
-import sm from "../../../assets/donation-sizes/xs.png";
 import customTheme from "../../../theme";
 import RadioImageSelectGroup from "../../common/RadioImageSelectGroup";
 import SchedulingProgressBar from "../../common/SchedulingProgressBar";
 import ErrorMessages from "./ErrorMessages";
-import { DonationSizeInterface, SchedulingStepProps } from "./types";
+import { categoriesOptions, DonationSizes, SchedulingStepProps } from "./types";
 
 const DonationInformation: any = ({
   formValues,
@@ -64,44 +60,6 @@ const DonationInformation: any = ({
       categories: "",
     });
   };
-
-  const DonationSizes: DonationSizeInterface[] = [
-    {
-      image: sm,
-      size: "Small",
-      description: "Fills less than a shelf of the fridge/pantry",
-    },
-    {
-      image: md,
-      size: "Medium",
-      description: "Approximately fills one shelf of the fridge/pantry",
-    },
-    {
-      image: lg,
-      size: "Large",
-      description: "Approximately fills two shelves of the fridge/pantry",
-    },
-    {
-      image: xl,
-      size: "Extra-large",
-      description:
-        "Approximately fills four shelves of the fridge/ pantry (full capacity)",
-    },
-  ];
-
-  const categoriesOptions = [
-    "Dry packaged goods",
-    "Non-perishables",
-    "Fresh produce",
-    "Bread and baked goods",
-    "Oil, spreads, and seasoning",
-    "Tea and coffee",
-    "Frozen meals",
-    "Prepared meals",
-    "Non-alcoholic drinks and juices",
-    "Essential items (masks, hand sanitizer, bags)",
-    "Hygiene products (tampons, pads, soap, etc.)",
-  ];
 
   const validateForm = () => {
     const newErrors = {

--- a/frontend/src/components/pages/Scheduling/types.ts
+++ b/frontend/src/components/pages/Scheduling/types.ts
@@ -1,5 +1,9 @@
 import { NavigationProps, SetForm } from "react-hooks-helper";
 
+import xl from "../../../assets/donation-sizes/lg.png";
+import lg from "../../../assets/donation-sizes/md.png";
+import md from "../../../assets/donation-sizes/sm.png";
+import sm from "../../../assets/donation-sizes/xs.png";
 import { Schedule } from "../../../types/SchedulingTypes";
 
 export interface SchedulingStepProps {
@@ -73,5 +77,43 @@ export const timeRanges = {
   ],
   night: ["9:00 PM - 10:00 PM", "10:00 PM - 11:00 PM", "11:00 PM - 12:00 AM"],
 };
+
+export const DonationSizes: DonationSizeInterface[] = [
+  {
+    image: sm,
+    size: "Small",
+    description: "Fills less than a shelf of the fridge/pantry",
+  },
+  {
+    image: md,
+    size: "Medium",
+    description: "Approximately fills one shelf of the fridge/pantry",
+  },
+  {
+    image: lg,
+    size: "Large",
+    description: "Approximately fills two shelves of the fridge/pantry",
+  },
+  {
+    image: xl,
+    size: "Extra-large",
+    description:
+      "Approximately fills four shelves of the fridge/ pantry (full capacity)",
+  },
+];
+
+export const categoriesOptions = [
+  "Dry packaged goods",
+  "Non-perishables",
+  "Fresh produce",
+  "Bread and baked goods",
+  "Oil, spreads, and seasoning",
+  "Tea and coffee",
+  "Frozen meals",
+  "Prepared meals",
+  "Non-alcoholic drinks and juices",
+  "Essential items (masks, hand sanitizer, bags)",
+  "Hygiene products (tampons, pads, soap, etc.)",
+];
 
 export const frequencies = ["One time", "Daily", "Weekly", "Monthly"];

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -20,7 +20,13 @@ const Button = {
       fontSize: "16px",
       py: "12px",
       px: "53px",
-    }
+    },
+    edit: {
+      color: "hubbard.100",
+      fontSize: "16px",
+      fontWeight: 300,
+      textDecoration: "underline",
+    },
   },
 };
 

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -14,6 +14,13 @@ const Button = {
       size: "lg",
       width: "100%",
     },
+    deleteDonation: {
+      background: "tomato.100",
+      color: "squash.100",
+      fontSize: "16px",
+      py: "12px",
+      px: "53px",
+    }
   },
 };
 


### PR DESCRIPTION
Redo of #92 
## Brief description. What is this change? 
### [Dashboard Flow Enhancements](https://www.notion.so/uwblueprintexecs/Team-Hub-Phase-1-Enhancements-Phase-2-cf7744a5b04748059761c1649a61a463?p=39b5b3c869274d01b9228bf98b32bcca)

Styled the empty donation state on dashboard home page and added updated styling to donation details. Also added Delete Donation section that deletes a scheduled donation (not hooked up with popup modal though).

## Implementation description. How did you make this change?
* [Desktop View](https://drive.google.com/file/d/1yDuGseH6Z6vhMdLm22d2fIZDalT7QfWW/view?usp=sharing)
* [Mobile View](https://drive.google.com/file/d/18DPeSazXr1AS4uvSfDGBDwBM4jWETWYK/view?usp=sharing)

## Steps to test
1. Schedule some donations, delete them, check empty state of dashboard page.
2. Check if it's close to Figma designs

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] The appropriate tests if necessary have been written
