### PR TITLE
fix: account page loading for admin

### DIFF
--- a/frontend/src/APIClients/UserAPIClient.ts
+++ b/frontend/src/APIClients/UserAPIClient.ts
@@ -21,6 +21,22 @@ type UserResponse = {
   email: string;
 };
 
+const getUserById = async (id: string): Promise<UserResponse> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+
+  try {
+    const { data } = await baseAPIClient.get(`/users/${id}`, {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    return error as UserResponse;
+  }
+};
+
 const updateUserById = async (
   id: string,
   {
@@ -44,4 +60,4 @@ const updateUserById = async (
   }
 };
 
-export default { updateUserById };
+export default { getUserById, updateUserById };

--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -13,8 +13,11 @@ import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import DonorAPIClient from "../../APIClients/DonorAPIClient";
+import UserAPIClient from "../../APIClients/UserAPIClient";
 import * as Routes from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
+import { Role } from "../../types/AuthTypes";
+import { DonorResponse } from "../../types/DonorTypes";
 
 const Account = (): JSX.Element => {
   const history = useHistory();
@@ -30,7 +33,30 @@ const Account = (): JSX.Element => {
       return;
     }
     const getDonor = async () => {
-      const donor = await DonorAPIClient.getDonorByUserId(authenticatedUser.id);
+      let donor: DonorResponse = {
+        id: "",
+        businessName: "",
+        firstName: "",
+        lastName: "",
+        role: "",
+        email: "",
+        phoneNumber: "",
+        userId: "",
+      };
+      if (authenticatedUser.role === Role.ADMIN) {
+        const userResponse = await UserAPIClient.getUserById(
+          authenticatedUser.id,
+        );
+        donor = {
+          ...userResponse,
+          businessName: "Community Fridge KW",
+          firstName: "Admin",
+          lastName: "Admin",
+          userId: "",
+        };
+      } else {
+        donor = await DonorAPIClient.getDonorByUserId(authenticatedUser.id);
+      }
       setBusinessName(donor.businessName);
     };
     getDonor();


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [My Account Page will load forever for Admin](https://www.notion.so/uwblueprintexecs/My-Account-Page-will-load-forever-for-Admin-5ed21a9cc9a049d09aad8f53832ed186)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Checks `authenticatedUser.role` to dictate if user account info should be pulled from donor table or user table in database (admins are not accounted for in the donor table)


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login to an admin account (or create one using uwblueprint email)
2. Navigate to My Account tab
3. Page should load with account details, business name is Community Fridge KW




## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] The appropriate tests if necessary have been written
