### PR TITLE
fix: small volunteer info screen bugs

### DIFF
--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -284,14 +284,18 @@ const ConfirmDetails = ({
           <Text textStyle="mobileBody">
             {currentSchedule.volunteerNeeded ? "Yes" : "No"}
           </Text>
-          <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
-            Pickup Needed
-          </Text>
-          <Text textStyle="mobileBody">
-            {currentSchedule.isPickup ? "Yes" : "No"}
-          </Text>
+          {currentSchedule.volunteerNeeded && (
+            <>
+              <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
+                Pickup Needed
+              </Text>
+              <Text textStyle="mobileBody">
+                {currentSchedule.isPickup ? "Yes" : "No"}
+              </Text>
+            </>
+          )}
 
-          {currentSchedule.isPickup && (
+          {currentSchedule.volunteerNeeded && currentSchedule.isPickup && (
             <Box>
               <Text textStyle="mobileSmall" color="hubbard.100" pt="1.4em">
                 Address

--- a/frontend/src/components/pages/Scheduling/VolunteerInformation.tsx
+++ b/frontend/src/components/pages/Scheduling/VolunteerInformation.tsx
@@ -100,7 +100,7 @@ const VolunteerInformation = ({
       valid = false;
       newErrors.volunteerNeeded = ErrorMessages.requiredField;
     }
-    if (volunteerNeeded && isPickup === undefined) {
+    if (volunteerNeeded && (isPickup === undefined || isPickup === null)) {
       valid = false;
       newErrors.isPickup = ErrorMessages.requiredField;
     }


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### 

https://www.notion.so/uwblueprintexecs/Hide-old-values-after-making-edit-to-donation-09818f546bb54681b545b97d766b2565
https://www.notion.so/uwblueprintexecs/Fix-required-for-volunteerNeeded-field-06e6dbba65904bd7b0eb7a0fb1294e9a


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* for hiding old values, made a quick fix, but for a more robust solution, we should update the values in backend as well (smth for later)


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.




## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
