### PR TITLE
fix: add spinner for email verification confirmation page

### DIFF
--- a/frontend/src/components/auth/Action.tsx
+++ b/frontend/src/components/auth/Action.tsx
@@ -1,30 +1,46 @@
-import { Center } from "@chakra-ui/react";
+import { Center, Spinner } from "@chakra-ui/react";
 import React from "react";
 
 import AuthAPIClient from "../../APIClients/AuthAPIClient";
 import ConfirmVerificationPage from "./Signup/ConfirmVerificationPage";
 
+enum EmailVerificationResponse {
+  SUCCESS = "SUCCESS",
+  FAILURE = "FAILURE",
+}
+
 const Action = () => {
   const urlParams = new URLSearchParams(window.location.search);
   const oobCode = urlParams.get("oobCode");
-  const [emailVerified, setEmailVerified] = React.useState(false);
+  const [emailVerified, setEmailVerified] = React.useState("");
 
   const confirmEmailVerification = async () => {
     const confirmEmailVerificationResponse = await AuthAPIClient.confirmEmailVerification(
       oobCode ?? "",
     );
     if (confirmEmailVerificationResponse) {
-      setEmailVerified(true);
+      setEmailVerified(EmailVerificationResponse.SUCCESS);
+    } else {
+      setEmailVerified(EmailVerificationResponse.FAILURE);
     }
   };
   React.useEffect(() => {
     confirmEmailVerification();
   }, []);
 
-  return emailVerified ? (
-    <ConfirmVerificationPage />
-  ) : (
-    <Center>Sorry, there was a problem verifying the email.</Center>
-  );
+
+  if (emailVerified === EmailVerificationResponse.SUCCESS) {
+    return <ConfirmVerificationPage />;
+  }
+
+  if (emailVerified === "") {
+    return (
+      <Center>
+        <Spinner />
+      </Center>
+    );
+  }
+
+  return <Center>Sorry, there was a problem verifying the email.</Center>;
 };
 export default Action;


### PR DESCRIPTION
Show a spinner when waiting for the email request instead of an incorrect falsy state.
![image](https://user-images.githubusercontent.com/19617248/151294545-9bff79b3-4dd1-46e1-82ba-7fa20ab71a59.png)

Tested emails are still able to be verified

