### PR TITLE
fix: change link to email header image

### DIFF
--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -181,7 +181,7 @@ class AuthService implements IAuthService {
         <title>Welcome Email</title>
       </head>
       <body>
-         <p><img src=https://i.ibb.co/txCj8db/drawer-logo.png
+         <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
                         style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
         <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717">Hey neighbour!</h2>
         <p>Thank you for getting involved with mutual aid through Community Fridge

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -249,7 +249,7 @@ class SchedulingService implements ISchedulingService {
      <title>Donation Details Email</title>
      </head>
      <body>
-        <p><img src=https://i.ibb.co/txCj8db/drawer-logo.png
+        <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
          style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
          <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717;">Hey there ${firstName}!</h2>
          <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Thank you for scheduling a donation to your local community fridge.


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Change the hosting of the email header image](https://www.notion.so/uwblueprintexecs/Change-the-hosting-of-the-email-header-image-693bcba7d3b14a9dad88e52773a628ba)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Hosting image in a public bucket on [Backblaze](https://www.backblaze.com/)


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create account and check that email verification header image is as expected
2. Schedule donation and check that donation confirmation email header image is as expected




## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] The appropriate tests if necessary have been written
