### PR TITLE
fix: style email to match figma

### DIFF
--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -232,9 +232,16 @@ class SchedulingService implements ISchedulingService {
         }
       }
 
-      const volunteerTimeString: string = dayjs(schedule.volunteerTime).format(
-        "h:mm A",
-      );
+      const volunteerTimeString = () => {
+        if (!!schedule.volunteerTime) {
+          const time_part_array = schedule.volunteerTime.split(":");
+          const AmOrPm = parseInt(time_part_array[0]) >= 12 ? 'PM' : 'AM';
+          const hour = parseInt(time_part_array[0]) % 12 || 12;
+          time_part_array[0] = String(hour);
+          const formatted_time = time_part_array[0] + ':' + time_part_array[1] + ' ' + AmOrPm;
+          return formatted_time;
+        }
+      }
 
 
       const emailBody = `<html>
@@ -256,7 +263,7 @@ class SchedulingService implements ISchedulingService {
         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Thank you for scheduling a donation to your local community fridge.
           <br />
           <br />
-          Here is a summary of your upcoming donation:
+          <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Here is a summary of your upcoming donation:</p>
         </p>
         <table style="display: block; margin-top: 2em; justify-content: space-between; max-width: 800px;">
           <tr>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -235,8 +235,8 @@ class SchedulingService implements ISchedulingService {
 
       dayjs.extend(customParseFormat);
 
-      
-      const volunteerTimeString = dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
+      const volunteerTimeString = 
+      dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
 
       const emailBody = `<html>
       <head>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -271,7 +271,7 @@ class SchedulingService implements ISchedulingService {
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Donation information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${schedule.size} - ${donationSizeDescriptions.get(
-                schedule.size ?? "")}
+                schedule.size ?? "",)}
                 <br />
                 ${schedule.categories.join(", ")}
               </p>
@@ -281,7 +281,10 @@ class SchedulingService implements ISchedulingService {
             <td style="display: inline-block; padding-right: 2em; vertical-align: top;">
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Volunteer information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
-                ${schedule.volunteerNeeded ? "Volunteer required": "Volunteer not required"}
+                ${schedule.volunteerNeeded 
+                  ? "Volunteer required"
+                  : "Volunteer not required"
+                }
                 <br />
                 ${schedule.isPickup ? "Pickup required" : "Pickup not required"}
                 <br />

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -238,7 +238,6 @@ class SchedulingService implements ISchedulingService {
         const AmOrPm = parseInt(timePartArray[0], 10) >= 12 ? "PM" : "AM";
         const hour = parseInt(timePartArray[0], 10) % 12 || 12;
         timePartArray[0] = String(hour);
-        
         volunteerTimeString = `${timePartArray.join(":")} ${AmOrPm}`;
       }
 

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -271,8 +271,8 @@ class SchedulingService implements ISchedulingService {
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Donation information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${schedule.size} - ${donationSizeDescriptions.get(
-                schedule.size ?? "",
-                )}
+        schedule.size ?? "",
+      )}
                 <br />
                 ${schedule.categories.join(", ")}
               </p>
@@ -283,9 +283,9 @@ class SchedulingService implements ISchedulingService {
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Volunteer information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${
-                  schedule.volunteerNeeded 
-                  ? "Volunteer required" 
-                  : "Volunteer not required"
+                  schedule.volunteerNeeded
+                    ? "Volunteer required"
+                    : "Volunteer not required"
                 }
                 <br />
                 ${schedule.isPickup ? "Pickup required" : "Pickup not required"}
@@ -299,7 +299,7 @@ class SchedulingService implements ISchedulingService {
         <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>
       </body>
-    </html>`;
+      </html>`;
 
       this.emailService.sendEmail(
         donor.email,

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -271,7 +271,8 @@ class SchedulingService implements ISchedulingService {
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Donation information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${schedule.size} - ${donationSizeDescriptions.get(
-                schedule.size ?? "",)}
+                schedule.size ?? "",
+                )}
                 <br />
                 ${schedule.categories.join(", ")}
               </p>
@@ -281,8 +282,9 @@ class SchedulingService implements ISchedulingService {
             <td style="display: inline-block; padding-right: 2em; vertical-align: top;">
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Volunteer information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
-                ${schedule.volunteerNeeded 
-                  ? "Volunteer required"
+                ${
+                  schedule.volunteerNeeded 
+                  ? "Volunteer required" 
                   : "Volunteer not required"
                 }
                 <br />

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -3,6 +3,7 @@ import { snakeCase } from "lodash";
 import { Op } from "sequelize";
 import dayjs from "dayjs";
 import ordinal from "ordinal";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import ISchedulingService from "../interfaces/schedulingService";
 import IEmailService from "../interfaces/emailService";
 import IDonorService from "../interfaces/donorService";
@@ -17,7 +18,6 @@ import {
 import logger from "../../utilities/logger";
 import Scheduling from "../../models/scheduling.model";
 import getErrorMessage from "../../utilities/errorMessageUtil";
-import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 const Logger = logger(__filename);
 
@@ -234,6 +234,7 @@ class SchedulingService implements ISchedulingService {
       }
 
       dayjs.extend(customParseFormat);
+      
       const volunteerTimeString = dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
 
       const emailBody = `<html>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -232,81 +232,67 @@ class SchedulingService implements ISchedulingService {
         }
       }
 
-      const emailBody = `
-      <html >
+      const emailBody = `<html>
       <head>
-        <link
-        href="https://fonts.googleapis.com/css2?family=Inter"
-        rel="stylesheet"
-        />
+        <link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet" />
         <style>
-         body {
-             font-family: "Inter";
-         }
-     </style>
-     <meta charset="utf-8" />
-     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-     <title>Donation Details Email</title>
-     </head>
-     <body>
-        <p><img src=https://i.ibb.co/txCj8db/drawer-logo.png
-         style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
-         <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717;">Hey there ${firstName}!</h2>
-         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Thank you for scheduling a donation to your local community fridge.
-         <br />
-         <br />
-         Here is a summary of your upcoming donation:
-     </p>
-     
-     <div style="display: flex; flex-direction: row; align-content: flex-start; gap: 20px;">
-         <div>
-             <h2 style="font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">
-                 Proposed drop-off time
-             </h2>
-             <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
-                 ${startDayString}
-                 <br />
-                 ${startTimeString} - ${endTimeString}
-                 <br />
-                 ${frequencyString}
-             </p>
-         </div>
-         <div>
-            <h2 style="font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">
-             Donation information
-         </h2>
-         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
-             ${schedule.size} - ${donationSizeDescriptions.get(
-        schedule.size ?? "",
-      )}
-             <br/>
-             ${schedule.categories.join(", ")}
-         </p>
-     
-     
-     </div>
-     </div>
-     
-     
-     <h2 style="font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">
-         Volunteer information
-     </h2>
-     <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
-         ${schedule.volunteerNeeded ? "Volunteer required" : ""}
-     <br/>
-     ${schedule.isPickup ? "Pickup required" : ""}
-     <br/>
-     ${schedule.isPickup ? schedule.pickupLocation : ""}
-     <br/>
-     ${schedule.notes ? `Additional Notes: ${schedule.notes}` : ""}
-     </p>
-     
-     
-     <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
-     <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>   
-     </body>
-     </html>
-      `;
+          body {
+            font-family: "Inter";
+            margin: 1.5em;
+          }
+        </style>
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <title>Donation Details Email</title>
+      </head>
+      <body>
+        <p><img src="https://i.ibb.co/txCj8db/drawer-logo.png" style="min-width: 100px; width: 25%; margin-bottom: 20px;" alt=" CFKW Logo" /></p>
+        <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;"><strong>Hey there ${firstName}!</strong></p>
+        <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Thank you for scheduling a donation to your local community fridge.
+          <br />
+          <br />
+          Here is a summary of your upcoming donation:
+        </p>
+        <table style="display: block; margin-top: 2em; justify-content: space-between; max-width: 800px;">
+          <tr>
+            <td style="display: inline-block; padding-right: 2em;">
+              <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">
+                Proposed drop-off time
+              </h2>
+              <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
+                ${startDayString}
+                <br />
+                ${startTimeString} - ${endTimeString}
+                <br />
+                ${frequencyString}
+              </p>
+            </td>
+            <td style="display: inline-block; padding-right: 2em;">
+              <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Donation information</h2>
+              <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
+                ${schedule.size} - ${donationSizeDescriptions.get(
+                schedule.size ?? "")}
+                <br />
+                ${schedule.categories.join(", ")}
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="display: inline-block; padding-right: 2em;">
+              <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Volunteer information</h2>
+              <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
+                ${schedule.volunteerNeeded ? "Volunteer required<br />": ""}
+                ${schedule.isPickup ? "Pickup required<br />" : ""}
+                ${schedule.isPickup ? `${schedule.pickupLocation}<br />}` : ""}
+                ${schedule.notes ? `Additional Notes: ${schedule.notes}` : ""}
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
+        <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>
+      </body>
+    </html>`;
 
       this.emailService.sendEmail(
         donor.email,

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -255,7 +255,7 @@ class SchedulingService implements ISchedulingService {
         <title>Donation Details Email</title>
       </head>
       <body>
-        <p><img src=https://i.ibb.co/txCj8db/drawer-logo.png style="min-width: 100px; width: 25%; margin-bottom: 20px;" alt=" CFKW Logo" /></p>
+        <p><img src=https://i.ibb.co/txCj8db/drawer-logo.png style="min-width: 100px; max-width: 200px; width: 25%; margin-bottom: 20px;" alt=" CFKW Logo" /></p>
         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;"><strong>Hey there ${firstName}!</strong></p>
         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Thank you for scheduling a donation to your local community fridge.
           <br />

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -232,15 +232,12 @@ class SchedulingService implements ISchedulingService {
         }
       }
 
-      const volunteerTimeString = () => {
-        if (!!schedule.volunteerTime) {
-          const time_part_array = schedule.volunteerTime.split(":");
-          const AmOrPm = parseInt(time_part_array[0]) >= 12 ? 'PM' : 'AM';
-          const hour = parseInt(time_part_array[0]) % 12 || 12;
-          time_part_array[0] = String(hour);
-          const formatted_time = time_part_array[0] + ':' + time_part_array[1] + ' ' + AmOrPm;
-          return formatted_time;
-        }
+      if (!!schedule.volunteerTime) {
+        const time_part_array = schedule.volunteerTime.split(":");
+        const AmOrPm = parseInt(time_part_array[0]) >= 12 ? 'PM' : 'AM';
+        const hour = parseInt(time_part_array[0]) % 12 || 12;
+        time_part_array[0] = String(hour);
+        schedule.volunteerTime = time_part_array[0] + ':' + time_part_array[1] + ' ' + AmOrPm;
       }
 
 
@@ -296,7 +293,7 @@ class SchedulingService implements ISchedulingService {
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${
                   schedule.volunteerNeeded
-                    ? `<br>Volunteer required at ${volunteerTimeString}</br>`
+                    ? `<strong>Volunteer required at ${schedule.volunteerTime}</strong>`
                     : "Volunteer not required"
                 }
                 <br />

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -238,8 +238,8 @@ class SchedulingService implements ISchedulingService {
         const AmOrPm = parseInt(timePartArray[0], 10) >= 12 ? "PM" : "AM";
         const hour = parseInt(timePartArray[0], 10) % 12 || 12;
         timePartArray[0] = String(hour);
-        volunteerTimeString = 
-        timePartArray[0] + ":" + timePartArray[1] + " " + AmOrPm;
+        
+        volunteerTimeString = `${timePartArray.join(":")} ${AmOrPm}`;
       }
 
       const emailBody = `<html>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -17,6 +17,7 @@ import {
 import logger from "../../utilities/logger";
 import Scheduling from "../../models/scheduling.model";
 import getErrorMessage from "../../utilities/errorMessageUtil";
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 const Logger = logger(__filename);
 
@@ -232,14 +233,8 @@ class SchedulingService implements ISchedulingService {
         }
       }
 
-      let volunteerTimeString = "";
-      if (schedule.volunteerTime) {
-        const timePartArray = schedule.volunteerTime.split(":");
-        const AmOrPm = parseInt(timePartArray[0], 10) >= 12 ? "PM" : "AM";
-        const hour = parseInt(timePartArray[0], 10) % 12 || 12;
-        timePartArray[0] = String(hour);
-        volunteerTimeString = `${timePartArray.join(":")} ${AmOrPm}`;
-      }
+      dayjs.extend(customParseFormat);
+      const volunteerTimeString = dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
 
       const emailBody = `<html>
       <head>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -246,7 +246,7 @@ class SchedulingService implements ISchedulingService {
         <title>Donation Details Email</title>
       </head>
       <body>
-        <p><img src="https://i.ibb.co/txCj8db/drawer-logo.png" style="min-width: 100px; width: 25%; margin-bottom: 20px;" alt=" CFKW Logo" /></p>
+        <p><img src=https://i.ibb.co/txCj8db/drawer-logo.png style="min-width: 100px; width: 25%; margin-bottom: 20px;" alt=" CFKW Logo" /></p>
         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;"><strong>Hey there ${firstName}!</strong></p>
         <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Thank you for scheduling a donation to your local community fridge.
           <br />
@@ -281,8 +281,10 @@ class SchedulingService implements ISchedulingService {
             <td style="display: inline-block; padding-right: 2em;">
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Volunteer information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
-                ${schedule.volunteerNeeded ? "Volunteer required<br />": ""}
-                ${schedule.isPickup ? "Pickup required<br />" : ""}
+                ${schedule.volunteerNeeded ? "Volunteer required": "Volunteer not required"}
+                <br />
+                ${schedule.isPickup ? "Pickup required" : "Pickup not required"}
+                <br />
                 ${schedule.isPickup ? `${schedule.pickupLocation}<br />}` : ""}
                 ${schedule.notes ? `Additional Notes: ${schedule.notes}` : ""}
               </p>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -234,6 +234,7 @@ class SchedulingService implements ISchedulingService {
       }
 
       dayjs.extend(customParseFormat);
+
       
       const volunteerTimeString = dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
 

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -234,9 +234,9 @@ class SchedulingService implements ISchedulingService {
       }
 
       dayjs.extend(customParseFormat);
-      
-      const volunteerTimeString = 
-      dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
+
+      const volunteerTimeString =
+        dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
 
       const emailBody = `<html>
       <head>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -234,7 +234,7 @@ class SchedulingService implements ISchedulingService {
       }
 
       dayjs.extend(customParseFormat);
-
+      
       const volunteerTimeString = 
       dayjs(schedule.volunteerTime, "HH:mm").format("h:mm A") ?? "";
 

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -255,7 +255,7 @@ class SchedulingService implements ISchedulingService {
         </p>
         <table style="display: block; margin-top: 2em; justify-content: space-between; max-width: 800px;">
           <tr>
-            <td style="display: inline-block; padding-right: 2em;">
+            <td style="display: inline-block; padding-right: 2em; vertical-align: top;">
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">
                 Proposed drop-off time
               </h2>
@@ -267,7 +267,7 @@ class SchedulingService implements ISchedulingService {
                 ${frequencyString}
               </p>
             </td>
-            <td style="display: inline-block; padding-right: 2em;">
+            <td style="display: inline-block; padding-right: 2em; vertical-align: top;">
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Donation information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${schedule.size} - ${donationSizeDescriptions.get(
@@ -278,14 +278,14 @@ class SchedulingService implements ISchedulingService {
             </td>
           </tr>
           <tr>
-            <td style="display: inline-block; padding-right: 2em;">
+            <td style="display: inline-block; padding-right: 2em; vertical-align: top;">
               <h2 style="margin: 0; font-weight: 600; font-size: 18px; line-height: 28px; color: #171717;">Volunteer information</h2>
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${schedule.volunteerNeeded ? "Volunteer required": "Volunteer not required"}
                 <br />
                 ${schedule.isPickup ? "Pickup required" : "Pickup not required"}
                 <br />
-                ${schedule.isPickup ? `${schedule.pickupLocation}<br />}` : ""}
+                ${schedule.isPickup ? `${schedule.pickupLocation}<br />` : ""}
                 ${schedule.notes ? `Additional Notes: ${schedule.notes}` : ""}
               </p>
             </td>

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -284,7 +284,7 @@ class SchedulingService implements ISchedulingService {
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${
                   schedule.volunteerNeeded
-                    ? "Volunteer required"
+                    ? `<br>Volunteer required at ${schedule.volunteerTime}</br>`
                     : "Volunteer not required"
                 }
                 <br />

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -232,6 +232,11 @@ class SchedulingService implements ISchedulingService {
         }
       }
 
+      const volunteerTimeString: string = dayjs(schedule.volunteerTime).format(
+        "h:mm A",
+      );
+
+
       const emailBody = `<html>
       <head>
         <link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet" />
@@ -284,7 +289,7 @@ class SchedulingService implements ISchedulingService {
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${
                   schedule.volunteerNeeded
-                    ? `<br>Volunteer required at ${schedule.volunteerTime}</br>`
+                    ? `<br>Volunteer required at ${volunteerTimeString}</br>`
                     : "Volunteer not required"
                 }
                 <br />

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -232,14 +232,15 @@ class SchedulingService implements ISchedulingService {
         }
       }
 
-      if (!!schedule.volunteerTime) {
-        const time_part_array = schedule.volunteerTime.split(":");
-        const AmOrPm = parseInt(time_part_array[0]) >= 12 ? 'PM' : 'AM';
-        const hour = parseInt(time_part_array[0]) % 12 || 12;
-        time_part_array[0] = String(hour);
-        schedule.volunteerTime = time_part_array[0] + ':' + time_part_array[1] + ' ' + AmOrPm;
+      let volunteerTimeString = "";
+      if (schedule.volunteerTime) {
+        const timePartArray = schedule.volunteerTime.split(":");
+        const AmOrPm = parseInt(timePartArray[0], 10) >= 12 ? "PM" : "AM";
+        const hour = parseInt(timePartArray[0], 10) % 12 || 12;
+        timePartArray[0] = String(hour);
+        volunteerTimeString = 
+        timePartArray[0] + ":" + timePartArray[1] + " " + AmOrPm;
       }
-
 
       const emailBody = `<html>
       <head>
@@ -293,7 +294,7 @@ class SchedulingService implements ISchedulingService {
               <p style="margin: 0.5em 0 1.5em 0; max-width: 400px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
                 ${
                   schedule.volunteerNeeded
-                    ? `<strong>Volunteer required at ${schedule.volunteerTime}</strong>`
+                    ? `<strong>Volunteer required at ${volunteerTimeString}</strong>`
                     : "Volunteer not required"
                 }
                 <br />


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Donation confirmation email styling](https://www.notion.so/uwblueprintexecs/Donation-confirmation-email-styling-3940a8c9b6d0482e8135448bb06be6ff)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Fixed designs to match Figma
* Used tables instead of flexbox (not supported by some email providers like Gmail)


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Schedule a donation, with volunteer and pickup needed + additional notes
2. Schedule a donation without volunteer needed - newly added to indicate `no volunteer/pickup needed`
3. Check confirmation email on Desktop and mobile
4. Make sure image is appropriate size and designs match Figma

Desktop - https://user-images.githubusercontent.com/69697180/152453462-e8c0c4ed-100b-4e8f-adea-520efe292d7f.mov
Mobile - https://user-images.githubusercontent.com/69697180/152452566-e2099158-be5c-4bae-ae34-84ee3839786a.MP4
Updated to emphasize volunteer time - 
![image](https://user-images.githubusercontent.com/69697180/152584574-3e4129f7-42d3-4f57-882f-361c80bd3187.png)



## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
