### PR TITLE
fix: make radio button circles clickable

### DIFF
--- a/frontend/src/components/common/RadioImageSelectGroup.tsx
+++ b/frontend/src/components/common/RadioImageSelectGroup.tsx
@@ -105,6 +105,7 @@ const RadioImageSelectGroup = (props: RadioImageSelectGroupProps) => {
         <VStack p="20px">
           <Flex alignItems="flex-start">
             <Radio
+              {...getRadioProps({ value: v.size })}
               isChecked={v.size === value}
               mx="10px"
               colorScheme="raddish"
@@ -126,6 +127,7 @@ const RadioImageSelectGroup = (props: RadioImageSelectGroupProps) => {
       ) : (
         <HStack alignItems="flex-start">
           <Radio
+            {...getRadioProps({ value: v.size })}
             isChecked={v.size === value}
             mx="10px"
             colorScheme="raddish"

--- a/frontend/src/components/common/RadioSelectGroup.tsx
+++ b/frontend/src/components/common/RadioSelectGroup.tsx
@@ -135,6 +135,7 @@ const RadioSelectGroup = (props: RadioSelectGroupProps) => {
       invalid={!!error}
     >
       <Radio
+        {...getRadioProps({ value: v })}
         isChecked={v === value}
         mr="16px"
         colorScheme="raddish"
@@ -146,7 +147,6 @@ const RadioSelectGroup = (props: RadioSelectGroupProps) => {
   ));
 
   const group = getRootProps();
-  const { isDesktop } = useViewport();
 
   return (
     <FormControl


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Radio buttons itself are not clickable](https://www.notion.so/uwblueprintexecs/Radio-buttons-itself-are-not-clickable-ca31149fea9740d6855dbc327dd56bc3)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Fixed radio buttons so that you can click on the circle



<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click on the circle of the radio buttons (for normal radio buttons + radio buttons w/ image for `Donation Size`)
2. Test on desktop and mobile

https://user-images.githubusercontent.com/69697180/153078635-8a0d1511-180c-4240-8edb-0361a224da8b.mov


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
