### PR TITLE
fix: recurring donation id integer and update fix

### DIFF
--- a/backend/typescript/models/scheduling.model.ts
+++ b/backend/typescript/models/scheduling.model.ts
@@ -71,8 +71,8 @@ export default class Scheduling extends Model {
   })
   frequency!: Frequency;
 
-  @Column({ type: DataType.TEXT })
-  recurring_donation_id!: string;
+  @Column({ type: DataType.INTEGER })
+  recurring_donation_id!: number;
 
   @Column({ type: DataType.DATE })
   recurring_donation_end_date!: Date;

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -356,8 +356,13 @@ class SchedulingService implements ISchedulingService {
         });
       } else {
         // get new recurring donation id
-        const newRecurringDonationId =
-          Number(await Scheduling.max("recurring_donation_id")) + 1;
+        let newRecurringDonationId: number | null = await Scheduling.max(
+          "recurring_donation_id",
+        );
+
+        newRecurringDonationId = newRecurringDonationId
+          ? newRecurringDonationId + 1
+          : 1;
 
         // end date of recurring donation
         const recurringDonationEndDate: Date = new Date(
@@ -548,7 +553,9 @@ class SchedulingService implements ISchedulingService {
     try {
       const updatesSnakeCase: Record<string, unknown> = {};
       Object.entries(scheduling).forEach(([key, value]) => {
-        updatesSnakeCase[snakeCase(key)] = value;
+        if (key !== "recurringDonationId") {
+          updatesSnakeCase[snakeCase(key)] = value;
+        }
       });
       const updateResult = await Scheduling.update(updatesSnakeCase, {
         where: { id: Number(schedulingId) },


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Recurring donation id fixes](https://www.notion.so/uwblueprintexecs/Repeat-recurring-ids-in-staging-4be9ad35bb4e464e9b02c204361cf64d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Changed recurring_donation_id to integer because the max function on string finds max lexographically so it doesnt find the max of numerical value (atleast thats my observation)
* Dont update recurring_donation_id in the update endpoint because updating it makes null as the string null (since FE sends it as sting null when editing) which we dont want.


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Please drop the scheduling table and add it again so that integer change is added. If you are confused how to do this, ping me on slack
2. Add, edit, delete schedules, and make sure everything is working as expected esp recurring_donation_id




## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
