### PR TITLE
feat: volunteer api client

### DIFF
--- a/backend/typescript/middlewares/validators/authValidators.ts
+++ b/backend/typescript/middlewares/validators/authValidators.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { nextTick } from "process";
 import { getApiValidationError, validatePrimitive } from "./util";
-import { Role } from "../../types";
+import { Role, Status } from "../../types";
 /* eslint-disable-next-line import/prefer-default-export */
 export const loginRequestValidator = async (
   req: Request,
@@ -45,10 +45,12 @@ export const registerRequestValidator = async (
   }
 
   if (req.body.role === Role.VOLUNTEER) {
+    if (req.body.status && !Object.values(Status).includes(req.body.status)) {
+      return res.status(400).send(getApiValidationError("status", "Status"));
+    }
     return next();
   }
-
-  if (req.body.role === "Donor") {
+  if (req.body.role === Role.DONOR) {
     if (
       req.body.facebookLink &&
       !validatePrimitive(req.body.facebookLink, "string")

--- a/backend/typescript/middlewares/validators/userValidators.ts
+++ b/backend/typescript/middlewares/validators/userValidators.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from "express";
-import { Role } from "../../types";
 import { getApiValidationError, validatePrimitive } from "./util";
 
 export const createUserDtoValidator = async (
@@ -18,6 +17,9 @@ export const createUserDtoValidator = async (
   }
   if (!validatePrimitive(req.body.role, "string")) {
     return res.status(400).send(getApiValidationError("role", "string"));
+  }
+  if (!validatePrimitive(req.body.phoneNumber, "string")) {
+    return res.status(400).send(getApiValidationError("phoneNumber", "string"));
   }
   if (!validatePrimitive(req.body.password, "string")) {
     return res.status(400).send(getApiValidationError("password", "string"));

--- a/backend/typescript/middlewares/validators/volunteerValidator.ts
+++ b/backend/typescript/middlewares/validators/volunteerValidator.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from "express";
+import { Status } from "../../types";
+import { getApiValidationError, validatePrimitive } from "./util";
+
+const volunteerDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (req.body.status && !Object.values(Status).includes(req.body.status)) {
+    return res.status(400).send(getApiValidationError("status", "Status"));
+  }
+
+  return next();
+};
+
+export default volunteerDtoValidator;

--- a/backend/typescript/models/volunteer.model.ts
+++ b/backend/typescript/models/volunteer.model.ts
@@ -7,7 +7,7 @@ import {
   BelongsTo,
   AllowNull,
 } from "sequelize-typescript";
-import { UserDTO } from "../types";
+import { Status } from "../types";
 import User from "./user.model";
 
 @Table({ tableName: "volunteers" })
@@ -19,4 +19,11 @@ export default class Volunteer extends Model {
 
   @BelongsTo(() => User)
   user!: User;
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.ENUM("Rejected", "Approved", "Pending"),
+    defaultValue: "Pending",
+  })
+  status!: Status;
 }

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -67,9 +67,9 @@ authRouter.post("/register", registerRequestValidator, async (req, res) => {
     if (req.body.role === Role.VOLUNTEER) {
       await volunteerService.createVolunteer({
         userId: user.id,
+        status: req.body.status,
       });
-    }
-    if (req.body.role === "Donor") {
+    } else if (req.body.role === Role.DONOR) {
       await donorService.createDonor({
         userId: user.id,
         businessName: req.body.businessName,

--- a/backend/typescript/services/interfaces/volunteerService.ts
+++ b/backend/typescript/services/interfaces/volunteerService.ts
@@ -1,4 +1,8 @@
-import { VolunteerDTO, UserVolunteerDTO } from "../../types";
+import {
+  VolunteerDTO,
+  UserVolunteerDTO,
+  UpdateVolunteerDTO,
+} from "../../types";
 
 interface IVolunteerService {
   /**
@@ -8,13 +12,22 @@ interface IVolunteerService {
    * @throws Error if volunteer creation fails
    */
   createVolunteer(volunteer: Omit<VolunteerDTO, "id">): Promise<VolunteerDTO>;
+
   /**
    * Get volunteer associated with id
    * @param id volunteer's id
    * @returns a VolunteerDTO with volunteer's information
    * @throws Error if volunteer retrieval fails
    */
-  getVolunteerByID(userId: string): Promise<UserVolunteerDTO>;
+  getVolunteerById(id: string): Promise<UserVolunteerDTO>;
+
+  /**
+   * Get volunteer associated with user id
+   * @param userId id associated with user
+   * @returns a VolunteerDTO with volunteer's information
+   * @throws Error if volunteer retrieval fails
+   */
+  getVolunteerByUserId(userId: string): Promise<UserVolunteerDTO>;
 
   /**
    * Get all volunteer information (possibly paginated in the future)
@@ -24,11 +37,30 @@ interface IVolunteerService {
   getVolunteers(): Promise<Array<UserVolunteerDTO>>;
 
   /**
+   * Update a volunteer by volunteerId.
+   * @param id volunteer's id
+   * @param volunteer the volunteer to be updated
+   * @throws Error if volunteer update fails
+   */
+  updateVolunteerById(id: string, volunteer: UpdateVolunteerDTO): Promise<void>;
+
+  /**
+   * Update a volunteer by userId.
+   * @param userId id associated with user
+   * @param volunteer the volunteer to be updated
+   * @throws Error if volunteer update fails
+   */
+  updateVolunteerByUserId(
+    userId: string,
+    volunteer: UpdateVolunteerDTO,
+  ): Promise<void>;
+
+  /**
    * Delete a volunteer by id
    * @param volunteerId volunteer's volunteerId
    * @throws Error if volunteer deletion fails
    */
-  deleteVolunteerByID(id: string): Promise<void>;
+  deleteVolunteerById(id: string): Promise<void>;
 }
 
 export default IVolunteerService;

--- a/backend/typescript/testUtils/volunteerService.ts
+++ b/backend/typescript/testUtils/volunteerService.ts
@@ -1,0 +1,73 @@
+import { Role, Status } from "../types";
+
+export const testUsers = [
+  {
+    email: "test1@test.com",
+    firstName: "Peter",
+    lastName: "Pan",
+    authId: "123",
+    role: Role.VOLUNTEER,
+    phoneNumber: "111-111-1111",
+  },
+  {
+    email: "test2@test.com",
+    firstName: "Wendy",
+    lastName: "Darling",
+    authId: "321",
+    role: Role.VOLUNTEER,
+    phoneNumber: "111-111-1111",
+  },
+];
+
+export const testVolunteers = [
+  {
+    userId: "1",
+    status: Status.PENDING,
+  },
+  {
+    userId: "2",
+    status: Status.PENDING,
+  },
+];
+
+export const testUserVolunteers = [
+  {
+    email: "test1@test.com",
+    firstName: "Peter",
+    lastName: "Pan",
+    role: Role.VOLUNTEER,
+    phoneNumber: "111-111-1111",
+    userId: "1",
+    status: Status.PENDING,
+  },
+  {
+    email: "test2@test.com",
+    firstName: "Wendy",
+    lastName: "Darling",
+    role: Role.VOLUNTEER,
+    phoneNumber: "111-111-1111",
+    userId: "2",
+    status: Status.PENDING,
+  },
+];
+
+export const testUpdatedUserVolunteers = [
+  {
+    email: "test1@test.com",
+    firstName: "Peter",
+    lastName: "Pan",
+    role: Role.VOLUNTEER,
+    phoneNumber: "111-111-1111",
+    userId: "1",
+    status: Status.APPROVED,
+  },
+  {
+    email: "test2@test.com",
+    firstName: "Wendy",
+    lastName: "Darling",
+    role: Role.VOLUNTEER,
+    phoneNumber: "111-111-1111",
+    userId: "2",
+    status: Status.REJECTED,
+  },
+];

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -75,6 +75,7 @@ export type DonorDTO = {
 export type VolunteerDTO = {
   id: string;
   userId: string;
+  status: Status;
 };
 
 export type UserDonorDTO = UserDTO & DonorDTO;
@@ -91,7 +92,7 @@ export type AuthDTO = Token & UserDTO;
 
 export type UserVolunteerDTO = UserDTO & VolunteerDTO;
 
-export type UpdateVolunteerDTO = Omit<VolunteerDTO, "id">;
+export type UpdateVolunteerDTO = Omit<VolunteerDTO, "id" | "userId">;
 
 export type SchedulingDTO = {
   id: string;

--- a/frontend/src/APIClients/VolunteerAPIClient.ts
+++ b/frontend/src/APIClients/VolunteerAPIClient.ts
@@ -1,0 +1,97 @@
+import { BEARER_TOKEN } from "../constants/AuthConstants";
+import {
+  UpdateVolunteerDataType,
+  VolunteerResponse,
+} from "../types/VolunteerTypes";
+import baseAPIClient from "./BaseAPIClient";
+
+const getAllVolunteers = async (): Promise<VolunteerResponse[]> => {
+  try {
+    const { data } = await baseAPIClient.get("/volunteers", {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as VolunteerResponse[];
+  }
+};
+
+const getVolunteerById = async (id: string): Promise<VolunteerResponse> => {
+  try {
+    const { data } = await baseAPIClient.get(`/volunteers/${id}`, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as VolunteerResponse;
+  }
+};
+
+const getVolunteerByUserId = async (
+  userId: string,
+): Promise<VolunteerResponse> => {
+  try {
+    const { data } = await baseAPIClient.get(`/volunteers/?userId=${userId}`, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as VolunteerResponse;
+  }
+};
+
+const updateVolunteerById = async (
+  id: string,
+  volunteerData: UpdateVolunteerDataType,
+): Promise<VolunteerResponse> => {
+  try {
+    const { data } = await baseAPIClient.put(
+      `/volunteers/${id}`,
+      volunteerData,
+      {
+        headers: { Authorization: BEARER_TOKEN },
+      },
+    );
+    return data;
+  } catch (error) {
+    return error as VolunteerResponse;
+  }
+};
+
+const updateVolunteerByUserId = async (
+  userId: string,
+  volunteerData: UpdateVolunteerDataType,
+): Promise<VolunteerResponse> => {
+  try {
+    const { data } = await baseAPIClient.put(
+      `/volunteers/?userId=${userId}`,
+      volunteerData,
+      {
+        headers: { Authorization: BEARER_TOKEN },
+      },
+    );
+    return data;
+  } catch (error) {
+    return error as VolunteerResponse;
+  }
+};
+
+const deleteVolunteerById = async (id: string): Promise<VolunteerResponse> => {
+  try {
+    const { data } = await baseAPIClient.delete(`/volunteers/${id}`, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as VolunteerResponse;
+  }
+};
+
+export default {
+  getAllVolunteers,
+  getVolunteerById,
+  getVolunteerByUserId,
+  updateVolunteerById,
+  updateVolunteerByUserId,
+  deleteVolunteerById,
+};

--- a/frontend/src/types/AuthTypes.ts
+++ b/frontend/src/types/AuthTypes.ts
@@ -34,17 +34,6 @@ export type AuthenticatedDonor = {
   instagramLink?: string;
 } | null;
 
-export type AuthenticatedVolunteer = {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  role: Role.VOLUNTEER;
-  accessToken: string;
-  phoneNumber: string;
-  status: Status;
-} | null;
-
 export type DecodedJWT =
   | string
   | null

--- a/frontend/src/types/AuthTypes.ts
+++ b/frontend/src/types/AuthTypes.ts
@@ -5,6 +5,12 @@ export enum Role {
   DONOR = "Donor",
 }
 
+export enum Status {
+  APPROVED = "Approved",
+  PENDING = "Pending",
+  REJECTED = "Rejected",
+}
+
 export type AuthenticatedUser = {
   id: string;
   firstName: string;
@@ -26,6 +32,17 @@ export type AuthenticatedDonor = {
   businessName: string;
   facebookLink?: string;
   instagramLink?: string;
+} | null;
+
+export type AuthenticatedVolunteer = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: Role.VOLUNTEER;
+  accessToken: string;
+  phoneNumber: string;
+  status: Status;
 } | null;
 
 export type DecodedJWT =

--- a/frontend/src/types/VolunteerTypes.ts
+++ b/frontend/src/types/VolunteerTypes.ts
@@ -1,0 +1,16 @@
+import { Role, Status } from "./AuthTypes";
+
+export type VolunteerResponse = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: Role.VOLUNTEER;
+  userId: string;
+  phoneNumber: string;
+  status: Status;
+};
+
+export type UpdateVolunteerDataType = {
+  status: Status;
+};

--- a/frontend/src/types/VolunteerTypes.ts
+++ b/frontend/src/types/VolunteerTypes.ts
@@ -11,6 +11,8 @@ export type VolunteerResponse = {
   status: Status;
 };
 
+export type AuthenticatedVolunteer = VolunteerResponse | null;
+
 export type UpdateVolunteerDataType = {
   status: Status;
 };


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Create VolunteerAPIClient file](https://www.notion.so/uwblueprintexecs/Create-VolunteerAPIClient-file-e2fa19da1db74c7ea158dffee96365b3)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Create a `VolunteerAPIClient` file that calls all the functions in `volunteerService.ts` 
* Add Volunteer types on FE with `VolunteerStatus` enum


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. We tested through the ```Dashboard``` page on frontend using the ```useEffect``` portion of the code. Here might be some helpful code to test:
```
    const getAllVolunteers = async () => {
      await VolunteerAPIClient.deleteVolunteerById("3");
      // await VolunteerAPIClient.updateVolunteerByUserId("6",
      // {
      //   status: Status.APPROVED
      // });
      const volunteer = await VolunteerAPIClient.getAllVolunteers();

      console.log(volunteer);
    };
```
2. Run through all the possible varieties under volunteering API client: ```getAllVolunteers```, ```getVolunteerById```, ```getVolunteerByUserId```, ```updateVolunteerById```, ```updateVolunteerByUserId```, ```deleteVolunteerById```

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [X] The appropriate tests if necessary have been written
