### PR TITLE
fix: only show upcoming donations in donor dashboard

### DIFF
--- a/backend/typescript/services/implementations/__tests__/schedulingService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/schedulingService.test.ts
@@ -103,8 +103,12 @@ describe("pg schedulingService", () => {
       donorId.toString(),
       0,
     );
+    const currentDate = new Date();
     expect(res).toMatchObject(
-      testSchedules.filter((schedule) => schedule.donorId === donorId),
+      testSchedules.filter(
+        (schedule) =>
+          schedule.donorId === donorId && schedule.startTime >= currentDate,
+      ),
     );
   });
 

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -94,8 +94,8 @@ class SchedulingService implements ISchedulingService {
     let schedulingDtos: Array<SchedulingDTO> = [];
     let schedulings: Array<Scheduling>;
     try {
+      const currentStartDate = new Date();
       if (weekLimit !== 0) {
-        const currentStartDate = new Date();
         const nextDate = new Date();
         nextDate.setDate(nextDate.getDate() + weekLimit * 7);
         schedulings = await Scheduling.findAll({
@@ -111,6 +111,9 @@ class SchedulingService implements ISchedulingService {
         schedulings = await Scheduling.findAll({
           where: {
             donor_id: Number(donorId),
+            start_time: {
+              [Op.gte]: currentStartDate,
+            },
           },
           order: [["start_time", "ASC"]],
         });


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Show only upcoming donations in donor dashboard](https://www.notion.so/uwblueprintexecs/Only-show-upcoming-donations-in-donor-dashboard-6df9a7d0e9574577bbc1635d4fd248fc)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?

<img width="733" alt="image" src="https://user-images.githubusercontent.com/37384882/156296469-2c81da2e-ef80-4688-b494-3315667d35ba.png">
Only upcoming donations are being shown


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.




## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
