### PR TITLE
feat: content backend model, route, validators, services and tests

### DIFF
--- a/backend/typescript/middlewares/validators/authValidators.ts
+++ b/backend/typescript/middlewares/validators/authValidators.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from "express";
-import { nextTick } from "process";
 import { getApiValidationError, validatePrimitive } from "./util";
 import { Role, Status } from "../../types";
 /* eslint-disable-next-line import/prefer-default-export */

--- a/backend/typescript/middlewares/validators/contentValidators.ts
+++ b/backend/typescript/middlewares/validators/contentValidators.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from "express";
+import { getApiValidationError, validatePrimitive } from "./util";
+
+const contentDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (
+    req.body.foodRescueDescription &&
+    !validatePrimitive(req.body.foodRescueDescription, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("foodRescueDescription", "string"));
+  }
+  if (
+    req.body.foodRescueUrl &&
+    !validatePrimitive(req.body.foodRescueUrl, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("foodRescueUrl", "string"));
+  }
+  if (
+    req.body.checkinDescription &&
+    !validatePrimitive(req.body.checkinDescription, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("checkinDescription", "string"));
+  }
+  if (
+    req.body.checkinUrl &&
+    !validatePrimitive(req.body.checkinUrl, "string")
+  ) {
+    return res.status(400).send(getApiValidationError("checkinUrl", "string"));
+  }
+
+  return next();
+};
+
+export default contentDtoValidator;

--- a/backend/typescript/models/content.model.ts
+++ b/backend/typescript/models/content.model.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  DataType,
+  Model,
+  Table,
+  AllowNull,
+} from "sequelize-typescript";
+
+@Table({ tableName: "content" })
+export default class Content extends Model {
+  @AllowNull(false)
+  @Column({ type: DataType.STRING })
+  food_rescue_description!: string;
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.STRING,
+    validate: {
+      isUrl: true,
+    },
+  })
+  food_rescue_url!: string;
+
+  @AllowNull(false)
+  @Column({ type: DataType.STRING })
+  checkin_description!: string;
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.STRING,
+    validate: {
+      isUrl: true,
+    },
+  })
+  checkin_url!: string;
+}

--- a/backend/typescript/rest/contentRoutes.ts
+++ b/backend/typescript/rest/contentRoutes.ts
@@ -8,7 +8,7 @@ import contentDtoValidator from "../middlewares/validators/contentValidators";
 const contentRouter: Router = Router();
 const contentService: IContentService = new ContentService();
 
-contentRouter.post("/", async (req, res) => {
+contentRouter.post("/", contentDtoValidator, async (req, res) => {
   try {
     const newContent = await contentService.createContent({
       ...req.body,

--- a/backend/typescript/rest/contentRoutes.ts
+++ b/backend/typescript/rest/contentRoutes.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+import ContentService from "../services/implementations/contentService";
+import IContentService from "../services/interfaces/contentService";
+import getErrorMessage from "../utilities/errorMessageUtil";
+import { sendResponseByMimeType } from "../utilities/responseUtil";
+import contentDtoValidator from "../middlewares/validators/contentValidators";
+
+const contentRouter: Router = Router();
+const contentService: IContentService = new ContentService();
+
+contentRouter.post("/", async (req, res) => {
+  try {
+    const newContent = await contentService.createContent({
+      ...req.body,
+    });
+    res.status(201).json(newContent);
+  } catch (error) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
+contentRouter.get("/", async (req, res) => {
+  const contentType = req.headers["content-type"];
+
+  try {
+    const contents = await contentService.getContent();
+    await sendResponseByMimeType(res, 200, contentType, contents);
+  } catch (error) {
+    await sendResponseByMimeType(res, 500, contentType, [
+      {
+        error: getErrorMessage(error),
+      },
+    ]);
+  }
+});
+
+contentRouter.put("/:id", contentDtoValidator, async (req, res) => {
+  try {
+    const updatedContent = await contentService.updateContent(req.params.id, {
+      ...req.body,
+    });
+    res.status(200).json(updatedContent);
+  } catch (error) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
+export default contentRouter;

--- a/backend/typescript/server.ts
+++ b/backend/typescript/server.ts
@@ -13,6 +13,7 @@ import volunteerRouter from "./rest/volunteerRoutes";
 import schedulingRouter from "./rest/schedulingRoutes";
 import EmailService from "./services/implementations/emailService";
 import IEmailService from "./services/interfaces/emailService";
+import contentRouter from "./rest/contentRoutes";
 
 const CORS_ALLOW_LIST: (string | RegExp)[] = ["http://localhost:3000"];
 if (process.env.NODE_ENV === "production") {
@@ -42,6 +43,7 @@ app.use("/donors", donorRouter);
 app.use("/users", userRouter);
 app.use("/volunteers", volunteerRouter);
 app.use("/scheduling", schedulingRouter);
+app.use("/content", contentRouter);
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 const eraseDatabaseOnSync = false;

--- a/backend/typescript/services/implementations/__tests__/contentService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/contentService.test.ts
@@ -1,0 +1,72 @@
+import { snakeCase } from "lodash";
+import Content from "../../../models/content.model";
+import ContentService from "../contentService";
+
+import testSql from "../../../testUtils/testDb";
+
+const mockContentData = {
+  foodRescueDescription: "test food rescue description",
+  foodRescueUrl: "uwblueprint.org",
+  checkinDescription: "test checkin description",
+  checkinUrl: "testurl.com",
+};
+
+const mockUpdateContentData = {
+  foodRescueDescription: "update test food rescue description",
+  foodRescueUrl: "update.uwblueprint.org",
+  checkinDescription: "update test checkin description",
+  checkinUrl: "update.testurl.com",
+};
+
+describe("Testing ContentService functions", () => {
+  let contentService: ContentService;
+
+  beforeEach(async () => {
+    await testSql.sync({ force: true });
+    contentService = new ContentService();
+  });
+
+  afterAll(async () => {
+    await testSql.sync({ force: true });
+    await testSql.close();
+  });
+
+  it("testing createContent", async () => {
+    const result = await contentService.createContent(mockContentData);
+    expect(result).toMatchObject({
+      id: "1",
+      ...mockContentData,
+    });
+  });
+
+  it("testing updateContent", async () => {
+    await Content.create({
+      food_rescue_description: mockContentData.foodRescueDescription,
+      food_rescue_url: mockContentData.foodRescueUrl,
+      checkin_description: mockContentData.checkinDescription,
+      checkin_url: mockContentData.checkinUrl,
+    });
+    const result = await contentService.updateContent(
+      "1",
+      mockUpdateContentData,
+    );
+    expect(result).toMatchObject({
+      id: "1",
+      ...mockUpdateContentData,
+    });
+  });
+
+  it("testing getContent", async () => {
+    await Content.create({
+      food_rescue_description: mockContentData.foodRescueDescription,
+      food_rescue_url: mockContentData.foodRescueUrl,
+      checkin_description: mockContentData.checkinDescription,
+      checkin_url: mockContentData.checkinUrl,
+    });
+    const result = await contentService.getContent();
+    expect(result).toMatchObject({
+      id: "1",
+      ...mockContentData,
+    });
+  });
+});

--- a/backend/typescript/services/implementations/contentService.ts
+++ b/backend/typescript/services/implementations/contentService.ts
@@ -61,9 +61,13 @@ class ContentService implements IContentService {
   }
 
   /* eslint-disable class-methods-use-this */
-  async updateContent(id: string, content: UpdateContentDTO): Promise<void> {
+  async updateContent(
+    id: string,
+    content: UpdateContentDTO,
+  ): Promise<ContentDTO> {
+    let updateResult: ContentDTO;
     try {
-      await Content.update(
+      const response = await Content.update(
         {
           food_rescue_description: content.foodRescueDescription,
           food_rescue_url: content.foodRescueUrl,
@@ -73,14 +77,24 @@ class ContentService implements IContentService {
         {
           where: { id },
           limit: 1,
+          returning: true,
         },
       );
+
+      updateResult = {
+        id: String(response[0]),
+        foodRescueDescription: content.foodRescueDescription,
+        foodRescueUrl: content.foodRescueUrl,
+        checkinDescription: content.checkinDescription,
+        checkinUrl: content.checkinUrl,
+      };
     } catch (error) {
       Logger.error(
         `Failed to update content. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }
+    return updateResult;
   }
 }
 

--- a/backend/typescript/services/implementations/contentService.ts
+++ b/backend/typescript/services/implementations/contentService.ts
@@ -1,0 +1,87 @@
+import { ContentDTO, CreateContentDTO, UpdateContentDTO } from "../../types";
+import IContentService from "../interfaces/contentService";
+import logger from "../../utilities/logger";
+import Content from "../../models/content.model";
+import getErrorMessage from "../../utilities/errorMessageUtil";
+
+const Logger = logger(__filename);
+
+class ContentService implements IContentService {
+  /* eslint-disable class-methods-use-this */
+  async createContent(content: CreateContentDTO): Promise<ContentDTO> {
+    let newContent: Content;
+
+    try {
+      newContent = await Content.create({
+        food_rescue_description: content.foodRescueDescription,
+        food_rescue_url: content.foodRescueUrl,
+        checkin_description: content.checkinDescription,
+        checkin_url: content.checkinUrl,
+      });
+    } catch (error) {
+      Logger.error(
+        `Failed to create content copy. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+    return {
+      id: newContent.id,
+      foodRescueDescription: newContent.food_rescue_description,
+      foodRescueUrl: newContent.food_rescue_url,
+      checkinDescription: newContent.checkin_description,
+      checkinUrl: newContent.checkin_url,
+    };
+  }
+
+  /* eslint-disable class-methods-use-this */
+  async getContent(): Promise<ContentDTO> {
+    let contentDto: ContentDTO | null;
+
+    try {
+      const contentResponse = await Content.findOne({
+        where: { id: 1 },
+      });
+
+      if (!contentResponse) {
+        throw new Error(`No content was found.`);
+      }
+      contentDto = {
+        id: contentResponse.id,
+        foodRescueDescription: contentResponse.food_rescue_description,
+        foodRescueUrl: contentResponse.food_rescue_url,
+        checkinDescription: contentResponse.checkin_description,
+        checkinUrl: contentResponse.checkin_url,
+      };
+    } catch (error) {
+      Logger.error(`Failed to get content. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    return contentDto;
+  }
+
+  /* eslint-disable class-methods-use-this */
+  async updateContent(id: string, content: UpdateContentDTO): Promise<void> {
+    try {
+      await Content.update(
+        {
+          food_rescue_description: content.foodRescueDescription,
+          food_rescue_url: content.foodRescueUrl,
+          checkin_description: content.checkinDescription,
+          checkin_url: content.checkinUrl,
+        },
+        {
+          where: { id },
+          limit: 1,
+        },
+      );
+    } catch (error) {
+      Logger.error(
+        `Failed to update content. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
+}
+
+export default ContentService;

--- a/backend/typescript/services/implementations/contentService.ts
+++ b/backend/typescript/services/implementations/contentService.ts
@@ -25,7 +25,7 @@ class ContentService implements IContentService {
       throw error;
     }
     return {
-      id: newContent.id,
+      id: String(newContent.id),
       foodRescueDescription: newContent.food_rescue_description,
       foodRescueUrl: newContent.food_rescue_url,
       checkinDescription: newContent.checkin_description,
@@ -46,7 +46,7 @@ class ContentService implements IContentService {
         throw new Error(`No content was found.`);
       }
       contentDto = {
-        id: contentResponse.id,
+        id: String(contentResponse.id),
         foodRescueDescription: contentResponse.food_rescue_description,
         foodRescueUrl: contentResponse.food_rescue_url,
         checkinDescription: contentResponse.checkin_description,

--- a/backend/typescript/services/implementations/contentService.ts
+++ b/backend/typescript/services/implementations/contentService.ts
@@ -82,11 +82,11 @@ class ContentService implements IContentService {
       );
 
       updateResult = {
-        id: String(response[0]),
-        foodRescueDescription: content.foodRescueDescription,
-        foodRescueUrl: content.foodRescueUrl,
-        checkinDescription: content.checkinDescription,
-        checkinUrl: content.checkinUrl,
+        id: String(response[1][0].id),
+        foodRescueDescription: response[1][0].food_rescue_description,
+        foodRescueUrl: response[1][0].food_rescue_url,
+        checkinDescription: response[1][0].checkin_description,
+        checkinUrl: response[1][0].checkin_url,
       };
     } catch (error) {
       Logger.error(

--- a/backend/typescript/services/interfaces/contentService.ts
+++ b/backend/typescript/services/interfaces/contentService.ts
@@ -21,7 +21,7 @@ interface IContentService {
    * @param id which is always 1 to retrieve the first entry
    * @throws Error if updating content fails
    */
-  updateContent(id: string, content: UpdateContentDTO): Promise<void>;
+  updateContent(id: string, content: UpdateContentDTO): Promise<ContentDTO>;
 }
 
 export default IContentService;

--- a/backend/typescript/services/interfaces/contentService.ts
+++ b/backend/typescript/services/interfaces/contentService.ts
@@ -1,0 +1,27 @@
+import { ContentDTO, CreateContentDTO, UpdateContentDTO } from "../../types";
+
+interface IContentService {
+  /**
+   * Create content description and url's for food rescue and checkins
+   * @param content a ContentDTO with the content information
+   * @returns a ContentDTO with the content information
+   * @throws Error if creation fails
+   */
+  createContent(content: CreateContentDTO): Promise<ContentDTO>;
+
+  /**
+   * Get content description and url's for food rescue and checkins
+   * @returns a ContentDTO with the content information
+   * @throws Error if getting content fails
+   */
+  getContent(): Promise<ContentDTO>;
+
+  /**
+   * Get content description and url's for food rescue and checkins
+   * @param id which is always 1 to retrieve the first entry
+   * @throws Error if updating content fails
+   */
+  updateContent(id: string, content: UpdateContentDTO): Promise<void>;
+}
+
+export default IContentService;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -78,6 +78,14 @@ export type VolunteerDTO = {
   status: Status;
 };
 
+export type ContentDTO = {
+  id: string;
+  foodRescueDescription: string;
+  foodRescueUrl: string;
+  checkinDescription: string;
+  checkinUrl: string;
+};
+
 export type UserDonorDTO = UserDTO & DonorDTO;
 
 export type CreateDonorDTO = Omit<DonorDTO, "id">;
@@ -93,6 +101,10 @@ export type AuthDTO = Token & UserDTO;
 export type UserVolunteerDTO = UserDTO & VolunteerDTO;
 
 export type UpdateVolunteerDTO = Omit<VolunteerDTO, "id" | "userId">;
+
+export type CreateContentDTO = Omit<ContentDTO, "id">;
+
+export type UpdateContentDTO = CreateContentDTO;
 
 export type SchedulingDTO = {
   id: string;

--- a/frontend/src/APIClients/ContentAPIClient.ts
+++ b/frontend/src/APIClients/ContentAPIClient.ts
@@ -1,0 +1,33 @@
+import { BEARER_TOKEN } from "../constants/AuthConstants";
+import { Content, UpdateContentDataType } from "../types/ContentTypes";
+import baseAPIClient from "./BaseAPIClient";
+
+const getContent = async (): Promise<Content> => {
+  try {
+    const { data } = await baseAPIClient.get("/content", {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as Content;
+  }
+};
+
+const updateContent = async (
+  id: string,
+  contentData: UpdateContentDataType,
+): Promise<Content> => {
+  try {
+    const { data } = await baseAPIClient.put(`/content/${id}`, contentData, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as Content;
+  }
+};
+
+export default {
+  getContent,
+  updateContent,
+};

--- a/frontend/src/types/ContentTypes.ts
+++ b/frontend/src/types/ContentTypes.ts
@@ -1,0 +1,9 @@
+export type Content = {
+  id: string;
+  foodRescueDescription: string;
+  foodRescueUrl: string;
+  checkinDescription: string;
+  checkinUrl: string;
+};
+
+export type UpdateContentDataType = Omit<Content, "id">;


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Content Backend Services](https://www.notion.so/uwblueprintexecs/Create-content-table-endpoint-services-4496bc2e234947cca58a9b54316889e9)

Essentially the admin team would like to have four attributes they can edit: 
```typescript

export type ContentDTO = {
  id: string;
  foodRescueDescription: string;
  foodRescueUrl: string;
  checkinDescription: string;
  checkinUrl: string;
};

```
Figma for context: 
<img width="396" alt="image" src="https://user-images.githubusercontent.com/19617248/156860139-a74da1fe-45d3-424c-afb2-4173899daf7f.png">

So we're introducing a new table with no relationships purely to support this functionality. This is copy that would appear on every single volunteer food rescue shift, and every single check-in shift. 
Based off the commits in this PR, we implement:
1. A content table, a `getContent`, `updateContent`, and `createContent` service. Note that in theory, the create content service is not used, was useful for testing and in the future for folk's local testing.
2. Frontend API Clients. We only need to expose the **Get** and **Update** for the admins since the will see the copy originally.
3. Unit tests for these three services.


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Pull the branch locally, use the following data to POST to `http://127.0.0.1:5000/content`
```
{
    "foodRescueDescription": "Test food description",
    "foodRescueUrl": "google.org",
    "checkinDescription": 123,
    "checkinUrl": "uwaterloo.ca"
}
```
3. Also verify that PUT `http://127.0.0.1:5000/content/1` and GET `http://127.0.0.1:5000/content` return as expected




## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s) 
- [X] The appropriate tests if necessary have been written
