### PR TITLE
fix: only use cfkw admin email in production environment

### DIFF
--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -19,7 +19,7 @@ import logger from "../../utilities/logger";
 import Scheduling from "../../models/scheduling.model";
 import getErrorMessage from "../../utilities/errorMessageUtil";
 import { toSnakeCase } from "../../utilities/servicesUtils";
-import { cancellationEmail } from "../../utilities/emailUtils";
+import { cancellationEmail, getAdminEmail } from "../../utilities/emailUtils";
 
 const Logger = logger(__filename);
 
@@ -451,7 +451,7 @@ class SchedulingService implements ISchedulingService {
       }
 
       this.emailService.sendEmail(
-        isAdmin ? "communityfridgekw@gmail.com" : email,
+        isAdmin ? getAdminEmail() : email,
         subject,
         emailBody,
       );

--- a/backend/typescript/utilities/emailUtils.ts
+++ b/backend/typescript/utilities/emailUtils.ts
@@ -59,3 +59,9 @@ export const cancellationEmail = (mainLine: string, name: string): string => {
  </html>
   `;
 };
+
+export const getAdminEmail = (): string => {
+  return process.env.NODE_ENV === "production"
+    ? "communityfridgekw@gmail.com"
+    : "hanlincheng@uwblueprint.org";
+};


### PR DESCRIPTION
Only use cfkw admin email when it's the production environment. Avoid spam for local and staging testing. 