### PR TITLE
chore: add eslint rule to remove unused imports

### DIFF
--- a/backend/typescript/.eslintrc.js
+++ b/backend/typescript/.eslintrc.js
@@ -15,7 +15,19 @@ module.exports = {
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
   ],
+  plugins: ["unused-imports"],
   rules: {
     "prettier/prettier": ["error", { endOfLine: "auto" }],
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "warn",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        vars: "all",
+        varsIgnorePattern: "^_",
+        args: "after-used",
+        argsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/backend/typescript/Dockerfile
+++ b/backend/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.5-slim
+FROM node:14.17.0-slim
 
 WORKDIR /app
 

--- a/backend/typescript/middlewares/validators/checkInValidators.ts
+++ b/backend/typescript/middlewares/validators/checkInValidators.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from "express";
-import { DayPart, Frequency, Status } from "../../types";
 import { getApiValidationError, validatePrimitive, validateDate } from "./util";
 
 export const createCheckInDtoValidator = async (

--- a/backend/typescript/middlewares/validators/volunteerValidator.ts
+++ b/backend/typescript/middlewares/validators/volunteerValidator.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { Status } from "../../types";
-import { getApiValidationError, validatePrimitive } from "./util";
+import { getApiValidationError } from "./util";
 
 const volunteerDtoValidator = async (
   req: Request,

--- a/backend/typescript/package.json
+++ b/backend/typescript/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dayjs": "^1.10.7",
     "dotenv": "^8.2.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "express": "^4.17.1",
     "firebase-admin": "^9.5.0",
     "lodash": "^4.17.21",

--- a/backend/typescript/services/implementations/__tests__/contentService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/contentService.test.ts
@@ -1,4 +1,3 @@
-import { snakeCase } from "lodash";
 import Content from "../../../models/content.model";
 import ContentService from "../contentService";
 

--- a/backend/typescript/yarn.lock
+++ b/backend/typescript/yarn.lock
@@ -2450,6 +2450,18 @@ eslint-plugin-prettier@^3.3.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  plugins: ["simple-import-sort"],
+  plugins: ["simple-import-sort", "unused-imports"],
   rules: {
     "prettier/prettier": ["warn", { endOfLine: "auto" }],
     "react/require-default-props": "off",
@@ -35,5 +35,16 @@ module.exports = {
     "sort-imports": "off",
     "simple-import-sort/imports": "warn",
     "simple-import-sort/exports": "warn",
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "warn",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        vars: "all",
+        varsIgnorePattern: "^_",
+        args: "after-used",
+        argsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.5-slim
+FROM node:14.17.0-slim
 
 WORKDIR /app
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "date-fns": "^2.25.0",
     "depcheck": "^1.4.2",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "framer-motion": "^4.1.17",
     "humps": "^2.0.1",
     "json-schema": "^0.3.0",

--- a/frontend/src/components/auth/Action.tsx
+++ b/frontend/src/components/auth/Action.tsx
@@ -1,9 +1,7 @@
 import { Center, Spinner } from "@chakra-ui/react";
 import React from "react";
-import { useStep } from "react-hooks-helper";
 
 import AuthAPIClient from "../../APIClients/AuthAPIClient";
-import { steps, UseStepType } from "./ResetPassword/index";
 import NewPassword from "./ResetPassword/NewPassword";
 import ConfirmVerificationPage from "./Signup/ConfirmVerificationPage";
 

--- a/frontend/src/components/auth/Signup/index.tsx
+++ b/frontend/src/components/auth/Signup/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { NavigationProps, Step, useForm, useStep } from "react-hooks-helper";
 
-import { Role } from "../../../types/AuthTypes";
 import AccountDetails from "./AccountDetails";
 import AccountType from "./AccountType";
 import CreateAccount from "./CreateAccount";

--- a/frontend/src/components/auth/utilities/index.ts
+++ b/frontend/src/components/auth/utilities/index.ts
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const checkLength = (val: string) => val.length >= 12;
 
 export const checkForNumbers = (val: string) => !!val.match(/\d+/g);

--- a/frontend/src/components/common/RadioSelectGroup.tsx
+++ b/frontend/src/components/common/RadioSelectGroup.tsx
@@ -8,10 +8,8 @@ import {
   Grid,
   Img,
   Radio,
-  SimpleGrid,
   useRadio,
   useRadioGroup,
-  VStack,
 } from "@chakra-ui/react";
 import React from "react";
 

--- a/frontend/src/components/pages/Scheduling/CancelEditsButton.tsx
+++ b/frontend/src/components/pages/Scheduling/CancelEditsButton.tsx
@@ -1,4 +1,4 @@
-import { Button, CloseButton, Flex } from "@chakra-ui/react";
+import { CloseButton, Flex } from "@chakra-ui/react";
 import React from "react";
 
 import { ButtonProps } from "./types";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5923,6 +5923,18 @@ eslint-plugin-testing-library@^3.9.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^3.10.1"
 
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Enable back unused imports rule](https://www.notion.so/uwblueprintexecs/Enable-back-https-www-npmjs-com-package-eslint-plugin-unused-imports-1f32f768112a48a191b17257d6bfc195)

Add back eslint rule for removing unused imports, will remove when the standard `yarn fix` is run at linting.
Set it to a warning so it compiles when in the middle of development. 