### PR TITLE
refactor: extract email header and footer

### DIFF
--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -7,6 +7,7 @@ import { AuthDTO, Role, Token } from "../../types";
 import FirebaseRestClient from "../../utilities/firebaseRestClient";
 import logger from "../../utilities/logger";
 import getErrorMessage from "../../utilities/errorMessageUtil";
+import { emailHeader, emailFooter } from "../../utilities/emailUtils";
 
 const Logger = logger(__filename);
 
@@ -134,24 +135,8 @@ class AuthService implements IAuthService {
         .generatePasswordResetLink(email);
       const emailBody = `
       <html>
-      <head>
-         <link
-                        href="https://fonts.googleapis.com/css2?family=Inter"
-                        rel="stylesheet"
-                        />
-                    <style>
-                        body {
-                        font-family: "Inter";
-                        }
-                    </style>
-        <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <title>Reset Password</title>
-      </head>
+      ${emailHeader}
       <body>
-        <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
-                        style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/>
-        </p>
         <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717">Hi there,</h2>
         <p> 
           This is an email verifying your request to change your password for Community Fridge. Please click on “Change Password” if you’d like to create a new password for the Community Fridge KW platform. 
@@ -180,8 +165,7 @@ class AuthService implements IAuthService {
         <div> 
           If you didn't request this reset link, you can safely ignore this email.
         </div>
-        <p style = "margin-top: 50px"> Sincerely, </p>
-        <p> Community Fridge KW </p>   
+        ${emailFooter}
       </body>
       </html>`;
 
@@ -209,23 +193,8 @@ class AuthService implements IAuthService {
 
       const emailBody = `
       <html>
-      <head>
-         <link
-                        href="https://fonts.googleapis.com/css2?family=Inter"
-                        rel="stylesheet"
-                        />
-                    <style>
-                        body {
-                        font-family: "Inter";
-                        }
-                    </style>
-        <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <title>Welcome Email</title>
-      </head>
+      ${emailHeader}
       <body>
-         <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
-                        style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
         <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717">Hey neighbour!</h2>
         <p>Thank you for getting involved with mutual aid through Community Fridge
           KW. We’re thrilled to have you.
@@ -250,9 +219,7 @@ class AuthService implements IAuthService {
        <div style="width: 100%"> <div style=" float:left; color: #6C6C84">Don't see a button above? </div><a style=" color: #C31887" href=${emailVerificationLink}> Verify yourself here</a></div>
        <div> If you didn't request this verification
        link, you can safely ignore this email.</div>
-     
-       <p style="margin-top: 50px">Sincerely,</p>
-        <p>Community Fridge KW</p>   
+       ${emailFooter} 
       </body>
     </html>
       `;
@@ -277,30 +244,14 @@ class AuthService implements IAuthService {
     try {
       const emailBody = `
       <html>
-      <head>
-         <link
-                        href="https://fonts.googleapis.com/css2?family=Inter"
-                        rel="stylesheet"
-                        />
-                    <style>
-                        body {
-                        font-family: "Inter";
-                        }
-                    </style>
-        <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <title>PENDING - Volunteer Account Status</title>
-      </head>
+      ${emailHeader}
       <body>
-         <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
-                        style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
         <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717">Hey there,</h2>
         <p>Thank you for your interest in volunteering with Community Fridge KW!<br /><br />
         Your account is <strong>pending approval</strong>. After an admin approves your account, you will be notified via email and will be able to start signing up for volunteer shifts!<br /><br />
         In the meantime, if you have any questions, please reach out at communityfridge@uwblueprint.org.
         </p>
-       <p style="margin-top: 50px">Sincerely,</p>
-        <p>Community Fridge KW</p>   
+       ${emailFooter}
       </body>
     </html>
       `;

--- a/backend/typescript/services/implementations/cronService.ts
+++ b/backend/typescript/services/implementations/cronService.ts
@@ -9,6 +9,7 @@ import User from "../../models/user.model";
 import getErrorMessage from "../../utilities/errorMessageUtil";
 import ICronService from "../interfaces/cronService";
 import IDonorService from "../interfaces/donorService";
+import { emailHeader, emailFooter } from "../../utilities/emailUtils";
 
 // eslint-disable-next-line
 const cron = require("node-cron");
@@ -70,24 +71,8 @@ class CronService implements ICronService {
 
       const emailBody = `
         <html>
-          <head>
-            <link
-              href="https://fonts.googleapis.com/css2?family=Inter"
-              rel="stylesheet"
-            />
-            <style>
-              body {
-                  font-family: "Inter";
-              }
-            </style>
-            <meta charset="utf-8" />
-            <meta http-equiv="x-ua-compatible" content="ie=edge" />
-            <title>Donation Details Email</title>
-          </head>
+          ${emailHeader}
           <body>
-            <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
-            style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
-            
             <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
               <strong>Hey there ${firstName}!</strong>
                 <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
@@ -102,8 +87,7 @@ class CronService implements ICronService {
                   : ``
               }
             </p>
-            <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
-            <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>   
+            ${emailFooter}
           </body>
         </html>
       `;

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -19,7 +19,12 @@ import logger from "../../utilities/logger";
 import Scheduling from "../../models/scheduling.model";
 import getErrorMessage from "../../utilities/errorMessageUtil";
 import { toSnakeCase } from "../../utilities/servicesUtils";
-import { cancellationEmail, getAdminEmail, emailHeader, emailFooter } from "../../utilities/emailUtils";
+import {
+  cancellationEmail,
+  getAdminEmail,
+  emailHeader,
+  emailFooter,
+} from "../../utilities/emailUtils";
 
 const Logger = logger(__filename);
 

--- a/backend/typescript/services/implementations/schedulingService.ts
+++ b/backend/typescript/services/implementations/schedulingService.ts
@@ -19,7 +19,7 @@ import logger from "../../utilities/logger";
 import Scheduling from "../../models/scheduling.model";
 import getErrorMessage from "../../utilities/errorMessageUtil";
 import { toSnakeCase } from "../../utilities/servicesUtils";
-import { cancellationEmail, getAdminEmail } from "../../utilities/emailUtils";
+import { cancellationEmail, getAdminEmail, emailHeader, emailFooter } from "../../utilities/emailUtils";
 
 const Logger = logger(__filename);
 
@@ -347,23 +347,8 @@ class SchedulingService implements ISchedulingService {
 
       const emailBody = `
         <html>
-          <head>
-            <link
-              href="https://fonts.googleapis.com/css2?family=Inter"
-              rel="stylesheet"
-            />
-            <style>
-              body {
-                  font-family: "Inter";
-              }
-            </style>
-            <meta charset="utf-8" />
-            <meta http-equiv="x-ua-compatible" content="ie=edge" />
-            <title>Donation Details Email</title>
-          </head>
+          ${emailHeader}
           <body>
-              <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/drawer-logo.png
-              style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
               
               <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">
               
@@ -454,8 +439,7 @@ class SchedulingService implements ISchedulingService {
          ? `<p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">If this is an error, please contact the CFKW admin team.</p>`
          : ""
      }
-     <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
-     <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>   
+     ${emailFooter}
      </body>
      </html>
       `;

--- a/backend/typescript/utilities/emailUtils.ts
+++ b/backend/typescript/utilities/emailUtils.ts
@@ -1,64 +1,59 @@
 import Schedule from "../models/scheduling.model";
 import User from "../models/user.model";
 
-export const createReminderEmailContent = (
-  schedule: Schedule,
-  user: User,
-): string => {
-  // TODO: need a final email body from designers
-
-  return `
-      <html>
-        <body>
-          Test content: ${user.email}
-        </body>
-      </html>
-    `;
-};
-
 export const cancellationEmail = (mainLine: string, name: string): string => {
   return `
-  <html >
-  <head>
-    <link
-    href="https://fonts.googleapis.com/css2?family=Inter"
-    rel="stylesheet"
-    />
-    <style>
-     body {
-         font-family: "Inter";
-     }
- </style>
- <meta charset="utf-8" />
- <meta http-equiv="x-ua-compatible" content="ie=edge" />
- <title>Donation Details Email</title>
- </head>
- <body>
-    <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
-     style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
-     <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717;">Hey there ${name}!</h2>
-     <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">${mainLine}
- </p>
- 
- <table cellspacing="0" cellpadding="0"> <tr> 
-      <td align="center" width="255" height="44" bgcolor="#C31887" style="-webkit-border-radius: 6px; -moz-border-radius: 6px; border-radius: 6px; color: #ffffff; display: block;">
-        <a href="https://communityfridgekw.web.app/" style="font-size:14px; font-weight: bold; font-family:sans-serif; text-decoration: none; line-height:40px; width:100%; display:inline-block">
-        <span style="color: #FAFCFE;">
-          View Dashboard
-        </span>
-        </a>
-      </td> 
-      </tr> </table> 
-        <p style="color:#6C6C84"> <b>Have a question?</b> <br/>
-          Contact Community Fridge KW at <a href="mailto: communityfridgekw@gmail.com">communityfridgekw@gmail.com </a>
-        </p>
-        <br/>
- <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
- <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>   
- </body>
- </html>
+    <html >
+    ${emailHeader}
+    <body>
+      <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717;">Hey there ${name}!</h2>
+      <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">${mainLine}
+      </p>
+      <table cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center" width="255" height="44" bgcolor="#C31887" style="-webkit-border-radius: 6px; -moz-border-radius: 6px; border-radius: 6px; color: #ffffff; display: block;">
+                <a href="https://communityfridgekw.web.app/" style="font-size:14px; font-weight: bold; font-family:sans-serif; text-decoration: none; line-height:40px; width:100%; display:inline-block">
+                <span style="color: #FAFCFE;">
+                View Dashboard
+                </span>
+                </a>
+            </td>
+          </tr>
+      </table>
+      <br/>
+      ${emailFooter}
+    </body>
+  </html>
   `;
 };
+
+export const emailHeader = `
+  <head>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter"
+        rel="stylesheet"
+        />
+    <style>
+        body {
+        font-family: "Inter";
+        }
+    </style>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>CFKW Email</title>
+  </head>
+  <p><img src=https://community-fridge-logo.s3.us-west-004.backblazeb2.com/community-fridge-logo.png
+    style="width: 134px; margin-bottom: 20px;  alt="CFKW Logo"/></p>
+  `;
+
+export const emailFooter = `
+  <footer>
+    <p style="margin-top: 50px; font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Sincerely,</p>
+    <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">Community Fridge KW</p>
+    <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;"><a href="mailto: info@communityfridgekw.ca">info@communityfridgekw.ca</a></p>
+    <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;"><a href="https://www.facebook.com/CommunityFridgeKW/" target="_blank">Facebook</a> | <a href="https://www.instagram.com/communityfridgekw/" target="_blank">Instagram</a></p>
+  </footer>
+  `;
 
 export const getAdminEmail = (): string => {
   return process.env.NODE_ENV === "production"

--- a/backend/typescript/utilities/emailUtils.ts
+++ b/backend/typescript/utilities/emailUtils.ts
@@ -1,32 +1,3 @@
-import Schedule from "../models/scheduling.model";
-import User from "../models/user.model";
-
-export const cancellationEmail = (mainLine: string, name: string): string => {
-  return `
-    <html >
-    ${emailHeader}
-    <body>
-      <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717;">Hey there ${name}!</h2>
-      <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">${mainLine}
-      </p>
-      <table cellspacing="0" cellpadding="0">
-          <tr>
-            <td align="center" width="255" height="44" bgcolor="#C31887" style="-webkit-border-radius: 6px; -moz-border-radius: 6px; border-radius: 6px; color: #ffffff; display: block;">
-                <a href="https://communityfridgekw.web.app/" style="font-size:14px; font-weight: bold; font-family:sans-serif; text-decoration: none; line-height:40px; width:100%; display:inline-block">
-                <span style="color: #FAFCFE;">
-                View Dashboard
-                </span>
-                </a>
-            </td>
-          </tr>
-      </table>
-      <br/>
-      ${emailFooter}
-    </body>
-  </html>
-  `;
-};
-
 export const emailHeader = `
   <head>
     <link
@@ -54,6 +25,32 @@ export const emailFooter = `
     <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;"><a href="https://www.facebook.com/CommunityFridgeKW/" target="_blank">Facebook</a> | <a href="https://www.instagram.com/communityfridgekw/" target="_blank">Instagram</a></p>
   </footer>
   `;
+
+export const cancellationEmail = (mainLine: string, name: string): string => {
+  return `
+      <html >
+      ${emailHeader}
+      <body>
+        <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717;">Hey there ${name}!</h2>
+        <p style="font-weight: 400; font-size: 16px; line-height: 24px; color: #171717;">${mainLine}
+        </p>
+        <table cellspacing="0" cellpadding="0">
+            <tr>
+              <td align="center" width="255" height="44" bgcolor="#C31887" style="-webkit-border-radius: 6px; -moz-border-radius: 6px; border-radius: 6px; color: #ffffff; display: block;">
+                  <a href="https://communityfridgekw.web.app/" style="font-size:14px; font-weight: bold; font-family:sans-serif; text-decoration: none; line-height:40px; width:100%; display:inline-block">
+                  <span style="color: #FAFCFE;">
+                  View Dashboard
+                  </span>
+                  </a>
+              </td>
+            </tr>
+        </table>
+        <br/>
+        ${emailFooter}
+      </body>
+    </html>
+    `;
+};
 
 export const getAdminEmail = (): string => {
   return process.env.NODE_ENV === "production"


### PR DESCRIPTION
## Brief description. What is this change? 
extract email header and footer
also added email + socials to footer 
![image](https://user-images.githubusercontent.com/19617248/162351344-115925d5-5d24-4f63-8513-f489b4ce195b.png)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* moved header and footer to emailUtils file 


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. make sure emails still show up properly




## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] The appropriate tests if necessary have been written
