### PR TITLE
fix: handle delete for checkin at top level of component

### DIFF
--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -65,7 +65,7 @@ const Login = (): React.ReactElement => {
 
   if (authenticatedUser) {
     return authenticatedUser.role === Role.ADMIN ? (
-      <Redirect to={Routes.ADMIN_VIEW_DONATIONS} />
+      <Redirect to={Routes.ADMIN_CHECK_INS} />
     ) : (
       <Redirect to={Routes.DASHBOARD_PAGE} />
     );

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -11,6 +11,7 @@ type CalendarProps = {
   items: Schedule[] | CheckIn[];
   isAdminView: boolean;
   isCheckInView: boolean;
+  deleteCheckIn: (checkInId: string) => void;
 };
 
 const Calendar = ({
@@ -18,6 +19,7 @@ const Calendar = ({
   items,
   isAdminView = false,
   isCheckInView = false,
+  deleteCheckIn,
 }: CalendarProps): React.ReactElement => {
   return (
     <WeeklyCalendar week={selectedDay}>
@@ -29,6 +31,7 @@ const Calendar = ({
             <CheckInInfoCard
               key={JSON.stringify(item)}
               checkIn={item as CheckIn}
+              deleteCheckIn={deleteCheckIn}
             />
           ) : (
             <DropoffCard

--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -106,7 +106,7 @@ const Account = (): JSX.Element => {
   const navigateToDashboard = () => {
     history.push(
       authenticatedUser!.role === Role.ADMIN
-        ? Routes.ADMIN_VIEW_DONATIONS
+        ? Routes.ADMIN_CHECK_INS
         : Routes.DASHBOARD_PAGE,
     );
   };

--- a/frontend/src/components/pages/AdminDashboard/ViewDonationsAndCheckIns.tsx
+++ b/frontend/src/components/pages/AdminDashboard/ViewDonationsAndCheckIns.tsx
@@ -60,6 +60,13 @@ const ViewDonationsAndCheckIns = ({
     setSelectedDay(newDate);
   };
 
+  const deleteCheckIn = (checkInId: string) => {
+    CheckInAPIClient.deleteCheckInById(checkInId);
+    setCheckIns([
+      ...checkIns.filter((checkIn: CheckIn) => checkIn.id !== checkInId),
+    ]);
+  };
+
   return (
     <Container alignContent="left" variant="calendarContainer">
       <Flex
@@ -161,6 +168,7 @@ const ViewDonationsAndCheckIns = ({
           items={isCheckInView ? checkIns : schedules}
           isAdminView={isAdminView}
           isCheckInView={isCheckInView}
+          deleteCheckIn={deleteCheckIn}
         />
       </Flex>
     </Container>

--- a/frontend/src/components/pages/AdminDashboard/components/CheckInInfoCard.tsx
+++ b/frontend/src/components/pages/AdminDashboard/components/CheckInInfoCard.tsx
@@ -24,7 +24,14 @@ import { CheckIn } from "../../../../types/CheckInTypes";
 import { VolunteerResponse } from "../../../../types/VolunteerTypes";
 import CardSubInformation from "../../../common/Card";
 
-const CheckInInfoCard = ({ checkIn }: { checkIn: CheckIn }): JSX.Element => {
+interface CheckInInfoCardProps {
+  checkIn: CheckIn;
+  deleteCheckIn: (checkInId: string) => void;
+}
+const CheckInInfoCard = ({
+  checkIn,
+  deleteCheckIn,
+}: CheckInInfoCardProps): JSX.Element => {
   const [volunteer, setVolunteer] = useState<VolunteerResponse>(
     {} as VolunteerResponse,
   );
@@ -67,10 +74,6 @@ const CheckInInfoCard = ({ checkIn }: { checkIn: CheckIn }): JSX.Element => {
       },
     );
     setCurrentCheckIn(checkInResponse);
-  };
-
-  const deleteCheckIn = async () => {
-    await CheckInAPIClient.deleteCheckInById(currentCheckIn.id);
   };
 
   const RemoveVolunteerButton = () => (
@@ -164,7 +167,10 @@ const CheckInInfoCard = ({ checkIn }: { checkIn: CheckIn }): JSX.Element => {
                     Edit
                   </Text>
                 </MenuItem>
-                <MenuItem style={menuItemStyle} onClick={deleteCheckIn}>
+                <MenuItem
+                  style={menuItemStyle}
+                  onClick={() => deleteCheckIn(currentCheckIn.id)}
+                >
                   <Text textStyle="mobileSmall" color="hubbard.100">
                     Delete
                   </Text>

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -95,7 +95,7 @@ const ConfirmDetails = ({
     }
     history.push(
       authenticatedUser!.role === Role.ADMIN
-        ? Routes.ADMIN_VIEW_DONATIONS
+        ? Routes.ADMIN_CHECK_INS
         : Routes.DASHBOARD_PAGE,
     );
   };
@@ -130,7 +130,7 @@ const ConfirmDetails = ({
             onClick={() =>
               history.push(
                 authenticatedUser?.role === Role.ADMIN
-                  ? Routes.ADMIN_VIEW_DONATIONS
+                  ? Routes.ADMIN_CHECK_INS
                   : Routes.DASHBOARD_PAGE,
               )
             }


### PR DESCRIPTION
## Brief description. What is this change? 
Previously, when we deleted check-ins, since the delete function was called inside of the `CheckInInfoCard` itself, the UI for the page would still display it since the parent compoennt `ViewDonationsAndCheckIns` wasn't re-rendered.
This lifts our function to the top and passed down as a handler so that we see it deleted visually.
![17e397b5-ffcd-4255-a22a-6843fb0b160b](https://user-images.githubusercontent.com/19617248/162350222-4696006a-a89e-41bd-b762-8728b1272cc3.gif)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
I know we're kind of passing it multiple times down the component tree but since it's a function it's just the reference and it's only twice so it should be fine, unnecessary abstraction doesn't seem necessary here.

<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create checkins
2. Sign in as admin navigate to view checkins
3. try deleting a checkin
