### PR TITLE
fix: checkin deletion backend unhandled promise error

### DIFF
--- a/backend/typescript/rest/checkInRoutes.ts
+++ b/backend/typescript/rest/checkInRoutes.ts
@@ -98,6 +98,17 @@ checkInRouter.delete("/:id?", async (req, res) => {
     return;
   }
 
+  if (id) {
+    try {
+      await checkInService.deleteCheckInById(id);
+      res.status(204).send();
+      return;
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+      return;
+    }
+  }
+
   if (!(startDate && endDate)) {
     await sendResponseByMimeType(res, 400, contentType, [
       {
@@ -105,15 +116,6 @@ checkInRouter.delete("/:id?", async (req, res) => {
       },
     ]);
     return;
-  }
-
-  if (id) {
-    try {
-      await checkInService.deleteCheckInById(id);
-      res.status(204).send();
-    } catch (error: unknown) {
-      res.status(500).json({ error: getErrorMessage(error) });
-    }
   }
 
   if (startDate && endDate) {

--- a/backend/typescript/rest/checkInRoutes.ts
+++ b/backend/typescript/rest/checkInRoutes.ts
@@ -98,15 +98,6 @@ checkInRouter.delete("/:id?", async (req, res) => {
     return;
   }
 
-  if (id) {
-    try {
-      await checkInService.deleteCheckInById(id);
-      res.status(204).send();
-    } catch (error: unknown) {
-      res.status(500).json({ error: getErrorMessage(error) });
-    }
-  }
-
   if (!(startDate && endDate)) {
     await sendResponseByMimeType(res, 400, contentType, [
       {
@@ -114,6 +105,15 @@ checkInRouter.delete("/:id?", async (req, res) => {
       },
     ]);
     return;
+  }
+
+  if (id) {
+    try {
+      await checkInService.deleteCheckInById(id);
+      res.status(204).send();
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
   }
 
   if (startDate && endDate) {
@@ -126,6 +126,7 @@ checkInRouter.delete("/:id?", async (req, res) => {
           error: "startDate and endDate must be valid dates",
         },
       ]);
+      return;
     }
     if (startDateRange.isAfter(endDateRange)) {
       await sendResponseByMimeType(res, 400, contentType, [
@@ -133,6 +134,7 @@ checkInRouter.delete("/:id?", async (req, res) => {
           error: "startDate must be before endDate",
         },
       ]);
+      return;
     }
     try {
       await checkInService.deleteCheckInsByDateRange(


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [[Bug] Backend warning for delete checkin function](https://www.notion.so/uwblueprintexecs/Backend-warning-for-delete-functions-6482b0f8a82b47409b0f5ec9ba624ea0)

Previously, when a checkin was getting deleted, the backend route would throw this error: 
<img width="758" alt="image" src="https://user-images.githubusercontent.com/19617248/162631872-685c94c9-f323-4926-8684-7eca1d6bcc8e.png">
Checkins were still being deleted successfully.
This happened because a response was already delivered to our client in the headers but the no `return` + ordering was causing an attempt at a header being set when the body is already written for the response. 

<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Delete a checkin either through postman or logged in as an admin
2. Make sure the docker logs aren't throwing this error anymore

