### PR TITLE
feat: send admin email on volunteer sign up

### DIFF
--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -85,6 +85,13 @@ authRouter.post("/register", registerRequestValidator, async (req, res) => {
 
     await authService.sendEmailVerificationLink(req.body.email);
 
+    if (req.body.role === Role.VOLUNTEER) {
+      await authService.sendAdminVolunteerSignUpEmail(
+        req.body.email,
+        `${req.body.firstName} ${req.body.lastName}`,
+      );
+    }
+
     res
       .cookie("refreshToken", refreshToken, {
         httpOnly: true,

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -280,9 +280,6 @@ class AuthService implements IAuthService {
       throw new Error(errorMessage);
     }
     try {
-      const emailVerificationLink = await firebaseAdmin
-        .auth()
-        .generateEmailVerificationLink(getAdminEmail());
       const emailBody = `<html>
       ${emailHeader}
       <body>
@@ -301,20 +298,12 @@ class AuthService implements IAuthService {
         </a>
       </td> 
       </tr> </table> 
-        <h5 style="font-weight: bold; font-size: 16px;
-      line-height: 22px; color: #6C6C84;">How does this work?</h5>
-        <p style="color:#6C6C84">This is a one-time URL that lets you confirm your
-          identity that lasts for 1 hour.
-        </p>
-       <div style="width: 100%"> <div style=" float:left; color: #6C6C84">Don't see a button above? </div><a style=" color: #C31887" href=${emailVerificationLink}> Verify yourself here</a></div>
-       <div> If you didn't request this verification
-       link, you can safely ignore this email.</div>
        ${emailFooter} 
       </body>
     </html>`;
       this.emailService.sendEmail(
         getAdminEmail(),
-        "Volunteer Approval Required",
+        `Volunteer Approval Required: ${fullName}`,
         emailBody,
       );
     } catch (error) {

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -7,7 +7,11 @@ import { AuthDTO, Role, Token } from "../../types";
 import FirebaseRestClient from "../../utilities/firebaseRestClient";
 import logger from "../../utilities/logger";
 import getErrorMessage from "../../utilities/errorMessageUtil";
-import { emailHeader, emailFooter } from "../../utilities/emailUtils";
+import {
+  emailHeader,
+  emailFooter,
+  getAdminEmail,
+} from "../../utilities/emailUtils";
 
 const Logger = logger(__filename);
 
@@ -260,6 +264,62 @@ class AuthService implements IAuthService {
     } catch (error) {
       Logger.error(
         `Failed to generate volunteer pending email for user with email ${email}`,
+      );
+      throw error;
+    }
+  }
+
+  async sendAdminVolunteerSignUpEmail(
+    email: string,
+    fullName: string,
+  ): Promise<void> {
+    if (!this.emailService) {
+      const errorMessage =
+        "Attempted to call sendAdminVolunteerSignUpEmail but this instance of AuthService does not have an EmailService instance";
+      Logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    try {
+      const emailVerificationLink = await firebaseAdmin
+        .auth()
+        .generateEmailVerificationLink(getAdminEmail());
+      const emailBody = `<html>
+      ${emailHeader}
+      <body>
+        <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717">A new volunteer has signed up!</h2>
+        <p>${fullName} is interested in becoming a volunteer.
+          <br />
+          <br />
+          Please approve this volunteer (${email}) for the Community Fridge KW volunteer by clicking "Approve"
+        </p>
+         <table cellspacing="0" cellpadding="0"> <tr> 
+      <td align="center" width="255" height="44" bgcolor="#C31887" style="-webkit-border-radius: 6px; -moz-border-radius: 6px; border-radius: 6px; color: #ffffff; display: block;">
+        <a href="https://schedule.communityfridgekw.ca/user-management" style="font-size:14px; font-weight: bold; font-family:sans-serif; text-decoration: none; line-height:40px; width:100%; display:inline-block">
+        <span style="color: #FAFCFE;">
+          Approve
+        </span>
+        </a>
+      </td> 
+      </tr> </table> 
+        <h5 style="font-weight: bold; font-size: 16px;
+      line-height: 22px; color: #6C6C84;">How does this work?</h5>
+        <p style="color:#6C6C84">This is a one-time URL that lets you confirm your
+          identity that lasts for 1 hour.
+        </p>
+       <div style="width: 100%"> <div style=" float:left; color: #6C6C84">Don't see a button above? </div><a style=" color: #C31887" href=${emailVerificationLink}> Verify yourself here</a></div>
+       <div> If you didn't request this verification
+       link, you can safely ignore this email.</div>
+       ${emailFooter} 
+      </body>
+    </html>`;
+      this.emailService.sendEmail(
+        getAdminEmail(),
+        "Volunteer Approval Required",
+        emailBody,
+      );
+    } catch (error) {
+      Logger.error(
+        `Failed to generate admin email for new volunteer sign up for volunteer with email ${email}`,
       );
       throw error;
     }

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -50,6 +50,14 @@ interface IAuthService {
   sendEmailVolunteerPending(email: string): Promise<void>;
 
   /**
+   * Sends admin an email alerting them of new volunteer sign up and asks for volunteer approval
+   * @param email email of volunteer that has pending status
+   * @param fullName of volunteer
+   * @throws Error if unable to send email
+   */
+  sendAdminVolunteerSignUpEmail(email: string, fullName: string): Promise<void>;
+
+  /**
    * Determine if the provided access token is valid and authorized for at least
    * one of the specified roles
    * @param accessToken user's access token


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Send admin email on volunteer sign up ](https://www.notion.so/uwblueprintexecs/Send-admin-email-on-volunteer-sign-up-7959dec109114983b0e59cb3ff22c66c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* implemented `sendAdminVolunteerSignUpEmail` and call it in `/register` auth route


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Replace line 316 in `sendAdminVolunteerSignUpEmail` in `authService.ts` with and email to use for testing that will receive the new volunteer sign up email
2. Create a volunteer account
3. Check that the email received is aligned with design

<img width="697" alt="Screen Shot 2022-04-10 at 2 55 17 PM" src="https://user-images.githubusercontent.com/38363056/162635195-62d540ea-d5be-45a9-b689-b2493d96ee7b.png">


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] The appropriate tests if necessary have been written
