### PR TITLE
fix: volunteer and admin default routing and add protections

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Community Fridge KW scheduling platform"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -138,6 +138,7 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
+                  donorOnly
                   path={Routes.SCHEDULING_PAGE}
                   component={Scheduling as React.FC}
                 />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,6 +85,7 @@ const App = (): React.ReactElement => {
                   component={UserManagement}
                 />
                 <PrivateRoute
+                  volunteerOnly
                   exact
                   path={Routes.VOLUNTEER_SHIFTS_PAGE}
                   component={VolunteerDashboard}
@@ -131,6 +132,7 @@ const App = (): React.ReactElement => {
                 />
                 <PrivateRoute
                   exact
+                  donorOnly
                   path={Routes.DASHBOARD_PAGE}
                   component={Dashboard}
                 />

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -64,11 +64,14 @@ const Login = (): React.ReactElement => {
   };
 
   if (authenticatedUser) {
-    return authenticatedUser.role === Role.ADMIN ? (
-      <Redirect to={Routes.ADMIN_CHECK_INS} />
-    ) : (
-      <Redirect to={Routes.DASHBOARD_PAGE} />
-    );
+    switch (authenticatedUser.role) {
+      case Role.ADMIN:
+        return <Redirect to={Routes.ADMIN_CHECK_INS} />;
+      case Role.VOLUNTEER:
+        return <Redirect to={Routes.VOLUNTEER_SHIFTS_PAGE} />;
+      default:
+        return <Redirect to={Routes.DASHBOARD_PAGE} />;
+    }
   }
 
   return (

--- a/frontend/src/components/auth/PrivateRoute.tsx
+++ b/frontend/src/components/auth/PrivateRoute.tsx
@@ -10,6 +10,8 @@ type PrivateRouteProps = {
   path: string;
   exact: boolean;
   adminOnly?: boolean;
+  volunteerOnly?: boolean;
+  donorOnly?: boolean;
 };
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({
@@ -17,11 +19,29 @@ const PrivateRoute: React.FC<PrivateRouteProps> = ({
   exact,
   path,
   adminOnly,
+  donorOnly,
+  volunteerOnly,
 }: PrivateRouteProps) => {
   const { authenticatedUser } = useContext(AuthContext);
 
   if (adminOnly) {
     return authenticatedUser?.role === Role.ADMIN ? (
+      <Route path={path} exact={exact} component={component} />
+    ) : (
+      <Redirect to={Routes.LANDING_PAGE} />
+    );
+  }
+
+  if (donorOnly) {
+    return authenticatedUser?.role === Role.DONOR ? (
+      <Route path={path} exact={exact} component={component} />
+    ) : (
+      <Redirect to={Routes.LANDING_PAGE} />
+    );
+  }
+
+  if (volunteerOnly) {
+    return authenticatedUser?.role === Role.VOLUNTEER ? (
       <Route path={path} exact={exact} component={component} />
     ) : (
       <Redirect to={Routes.LANDING_PAGE} />

--- a/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
+++ b/frontend/src/components/pages/Scheduling/ConfirmDetails.tsx
@@ -95,7 +95,7 @@ const ConfirmDetails = ({
     }
     history.push(
       authenticatedUser!.role === Role.ADMIN
-        ? Routes.ADMIN_CHECK_INS
+        ? Routes.ADMIN_VIEW_DONATIONS
         : Routes.DASHBOARD_PAGE,
     );
   };
@@ -130,7 +130,7 @@ const ConfirmDetails = ({
             onClick={() =>
               history.push(
                 authenticatedUser?.role === Role.ADMIN
-                  ? Routes.ADMIN_CHECK_INS
+                  ? Routes.ADMIN_VIEW_DONATIONS
                   : Routes.DASHBOARD_PAGE,
               )
             }


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
1. Add `volunteerOnly` and `donorOnly` route protections
2. When volunteer logs in right now it goes to donor dashboard which is incorrect, fixing that here
3. Fix the meta data on preview of the link

## Implementation description. How did you make this change?
When volunteer is logged in:
![Screen Shot 2022-04-14 at 5 54 53 PM](https://user-images.githubusercontent.com/19617248/163483765-1907f24f-f6e4-439b-b426-ff09b994a8f6.png)



<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as volunteer and check it defaults to volunteer shift page
2. Check that you can't access donorOnly or volunteerOnly routes even as an admin


