### PR TITLE
feat: Add confirmation modal when deleting a user

### DIFF
--- a/frontend/src/components/pages/UserManagement/index.tsx
+++ b/frontend/src/components/pages/UserManagement/index.tsx
@@ -153,7 +153,6 @@ const UserManagementPage = (): JSX.Element => {
     const deleteUserResponse = await UserAPIClient.deleteUserById(user!.userId);
     onClose();
     if (deleteUserResponse) {
-      console.log("jklhjgfdg");
       setUsers(users.filter((u) => u.id !== user!.id));
     }
     setUserToDelete(null);

--- a/frontend/src/components/pages/UserManagement/index.tsx
+++ b/frontend/src/components/pages/UserManagement/index.tsx
@@ -15,6 +15,7 @@ import {
   Th,
   Thead,
   Tr,
+  useDisclosure,
 } from "@chakra-ui/react";
 import React from "react";
 
@@ -24,6 +25,7 @@ import VolunteerAPIClient from "../../../APIClients/VolunteerAPIClient";
 import { Role, Status } from "../../../types/AuthTypes";
 import { DonorResponse } from "../../../types/DonorTypes";
 import { VolunteerDTO, VolunteerResponse } from "../../../types/VolunteerTypes";
+import GeneralDeleteShiftModal from "../../common/GeneralDeleteShiftModal";
 import {
   AccountFilterType,
   accountTypefilterOptions,
@@ -38,6 +40,11 @@ const UserManagementPage = (): JSX.Element => {
   const [selectedFilter, setSelectedFilter] = React.useState<string>(
     AccountFilterType.ALL,
   );
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [
+    userToDelete,
+    setUserToDelete,
+  ] = React.useState<UserMgmtTableRecord | null>(null);
 
   // Merge donors and volunteers into one list of type UserMgmtTableRecord
   const buildTableUsers = (): UserMgmtTableRecord[] => {
@@ -132,12 +139,21 @@ const UserManagementPage = (): JSX.Element => {
     }
   };
 
-  // Deletes selected user
+  // Show confirm delete modal
   const handleDeleteUser = async (user: UserMgmtTableRecord) => {
-    const deleteUserResponse = await UserAPIClient.deleteUserById(user.userId);
+    setUserToDelete(user);
+    onOpen();
+  };
+
+  // Deletes selected user
+  const handleConfirmDelete = async (user: UserMgmtTableRecord | null) => {
+    const deleteUserResponse = await UserAPIClient.deleteUserById(user!.userId);
+    onClose();
     if (deleteUserResponse) {
-      setUsers(users.filter((u) => u.id !== user.id));
+      console.log("jklhjgfdg");
+      setUsers(users.filter((u) => u.id !== user!.id));
     }
+    setUserToDelete(null);
   };
 
   // Selects a filter
@@ -147,6 +163,15 @@ const UserManagementPage = (): JSX.Element => {
 
   return (
     <Container variant="baseContainer">
+      <GeneralDeleteShiftModal
+        title="Delete a user"
+        bodyText="Are you sure you want to delete this user? This will remove all
+              linked occurences, including related donations and/or check-ins."
+        buttonLabel="Delete user"
+        isOpen={isOpen}
+        onClose={onClose}
+        onDelete={() => handleConfirmDelete(userToDelete)}
+      />
       <Text mb="40px" textStyle="desktopHeader2">
         User management
       </Text>


### PR DESCRIPTION
## Brief description. What is this change? 
### [Add confirmation modal when deleting user](https://www.notion.so/uwblueprintexecs/Add-confirmation-modal-when-deleting-user-ec18b44d364a43038bb50c8fe0be6f8a)

## Implementation description. How did you make this change?
* Display general modal to ask admin to confirm that they want to delete a user

<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as admin
2. Delete a user in User Management table
3. Confirmation should appear 
4. Cancelling should not have any effect
5. Confirming the delete should delete user as required

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
