### PR TITLE
fix: 24 hour date validation crash 

### DIFF
--- a/backend/typescript/middlewares/validators/schedulingValidators.ts
+++ b/backend/typescript/middlewares/validators/schedulingValidators.ts
@@ -6,6 +6,7 @@ import {
   validateDate,
   validateCategories,
   validateRecurringDonationEndDate,
+  validate24HourTime,
 } from "./util";
 
 export const createSchedulingDtoValidator = async (
@@ -68,6 +69,11 @@ export const createSchedulingDtoValidator = async (
     return res
       .status(400)
       .send(getApiValidationError("volunteerTime", "string"));
+  }
+  if (req.body.volunteerTime && !validate24HourTime(req.body.volunteerTime)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("volunteerTime", "24 Hour Time String"));
   }
   if (!Object.values(Frequency).includes(req.body.frequency)) {
     return res.status(400).send(getApiValidationError("frequency", "string"));
@@ -189,6 +195,11 @@ export const updateSchedulingDtoValidator = async (
     return res
       .status(400)
       .send(getApiValidationError("volunteerTime", "string"));
+  }
+  if (req.body.volunteerTime && !validate24HourTime(req.body.volunteerTime)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("volunteerTime", "24 Hour Time String"));
   }
   if (req.body.dayPart && !Object.values(DayPart).includes(req.body.dayPart)) {
     return res.status(400).send(getApiValidationError("dayPart", "string"));

--- a/backend/typescript/middlewares/validators/util.ts
+++ b/backend/typescript/middlewares/validators/util.ts
@@ -1,6 +1,12 @@
 import { Categories } from "../../types";
 
-type Type = "string" | "integer" | "boolean" | "Status" | "Date string";
+type Type =
+  | "string"
+  | "integer"
+  | "boolean"
+  | "Status"
+  | "Date string"
+  | "24 Hour Time String";
 
 const allowableContentTypes = new Set([
   "text/plain",
@@ -12,6 +18,11 @@ const allowableContentTypes = new Set([
 
 export const validateDate = (value: string): boolean => {
   return !!Date.parse(value);
+};
+
+export const validate24HourTime = (value: string): boolean => {
+  const regEx = new RegExp(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/);
+  return regEx.test(value);
 };
 
 export const validateRecurringDonationEndDate = (

--- a/frontend/src/components/pages/Dashboard/components/DropoffCard.tsx
+++ b/frontend/src/components/pages/Dashboard/components/DropoffCard.tsx
@@ -124,7 +124,7 @@ const DropoffCard = ({
                 value={
                   volunteerTime
                     ? format(
-                        parse(volunteerTime, "kk:mm", new Date()),
+                        parse(volunteerTime, "HH:mm", new Date()),
                         "h:mm aa",
                       )
                     : "-"

--- a/frontend/src/components/pages/FridgeManagement/FridgeCheckIns/EditCheckin.tsx
+++ b/frontend/src/components/pages/FridgeManagement/FridgeCheckIns/EditCheckin.tsx
@@ -36,16 +36,16 @@ const EditCheckInPage = (): JSX.Element => {
   const getCheckInData = async () => {
     const checkInResponse = await CheckInAPIClient.getCheckInsById(id);
     setDate(checkInResponse.startDate);
-    setStartTime(format(new Date(checkInResponse.startDate), "kk:mm"));
-    setEndTime(format(new Date(checkInResponse.endDate), "kk:mm"));
+    setStartTime(format(new Date(checkInResponse.startDate), "HH:mm"));
+    setEndTime(format(new Date(checkInResponse.endDate), "HH:mm"));
     setNotes(checkInResponse.notes);
   };
 
   const validateForm = () => {
     let newError = "";
     let valid = true;
-    const parsedStartTime = parse(startTime, "kk:mm", new Date());
-    const parsedEndTime = parse(endTime, "kk:mm", new Date());
+    const parsedStartTime = parse(startTime, "HH:mm", new Date());
+    const parsedEndTime = parse(endTime, "HH:mm", new Date());
 
     if (isAfter(parsedStartTime, parsedEndTime)) {
       valid = false;
@@ -65,8 +65,8 @@ const EditCheckInPage = (): JSX.Element => {
     }
 
     const checkInData: UpdateCheckInFields = {
-      startDate: parse(startTime, "kk:mm", new Date(date)).toString(),
-      endDate: parse(endTime, "kk:mm", new Date(date)).toString(),
+      startDate: parse(startTime, "HH:mm", new Date(date)).toString(),
+      endDate: parse(endTime, "HH:mm", new Date(date)).toString(),
       notes,
     };
 

--- a/frontend/src/components/pages/FridgeManagement/FridgeCheckIns/index.tsx
+++ b/frontend/src/components/pages/FridgeManagement/FridgeCheckIns/index.tsx
@@ -47,16 +47,16 @@ const CreateCheckIn = () => {
       newErrors.timeRange = ErrorMessages.bothTimeFieldsRequired;
     } else if (
       isAfter(
-        parse(startTime, "kk:mm", new Date()),
-        parse(endTime, "kk:mm", new Date()),
+        parse(startTime, "HH:mm", new Date()),
+        parse(endTime, "HH:mm", new Date()),
       )
     ) {
       valid = false;
       newErrors.timeRange = ErrorMessages.endTimeBeforeStartTime;
     } else if (
       isEqual(
-        parse(startTime, "kk:mm", new Date()),
-        parse(endTime, "kk:mm", new Date()),
+        parse(startTime, "HH:mm", new Date()),
+        parse(endTime, "HH:mm", new Date()),
       )
     ) {
       valid = false;
@@ -78,12 +78,12 @@ const CreateCheckIn = () => {
     const checkInData: CreateCheckInFields = {
       startDate: parse(
         startTime,
-        "kk:mm",
+        "HH:mm",
         new Date(dateRange![0].format()),
       ).toString(),
       endDate: parse(
         endTime,
-        "kk:mm",
+        "HH:mm",
         new Date(dateRange![1].format()),
       ).toString(),
       notes,

--- a/frontend/src/components/pages/VolunteerDashboard/ShiftCard.tsx
+++ b/frontend/src/components/pages/VolunteerDashboard/ShiftCard.tsx
@@ -62,7 +62,7 @@ const VolunteerShiftCard = ({
 
     return (
       volunteerTime &&
-      format(parse(volunteerTime, "kk:mm", new Date()), "h:mma")
+      format(parse(volunteerTime, "HH:mm", new Date()), "h:mma")
     );
   };
 


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Volunteer Time Crashing](https://www.notion.so/uwblueprintexecs/Donor-Dashboard-Crashing-6a4ea22631f84a3aa90e05496e071559)

Whenever a volunteer time was being created between midnight to 1am, it would be `00:23` for example. So 0-23 hour format. 
https://github.com/uwblueprint/community-fridge-kw/blob/419f7f72274944725f697f6627dbf8582a2b320f/frontend/src/components/pages/Scheduling/SelectDateTime.tsx#L75
But we were parsing it as `kk:mm` to display on the client side which is 1-24 hour format, causing an invalid time range error and the pages to crash in the `DropoffCard`. 
![image](https://user-images.githubusercontent.com/19617248/163511127-e95b5d11-dee7-49ec-b741-f9bf444c68c3.png)

See date-fns formatting here: https://date-fns.org/v2.28.0/docs/format
We should be using `HH:mm` instead. 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
![image](https://user-images.githubusercontent.com/19617248/163510973-5f4f032e-2303-48b2-9693-3cc067425459.png)
- Reverted the `kk:mm` parsing 
- Changed the check in time parsing to also be `HH:mm` for consistency (since our backend refers to it as such in scheduling emails)
- Added a validator to prevent this from happening again



<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Sign in as a donor, create a donation where the volunteer time is from midnight to 1AM
2. Verify you can see this donation in your dashboard


