### PR TITLE
feat: send email to volunteer when approved

### DIFF
--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -189,4 +189,20 @@ authRouter.post("/confirmPasswordReset/:newPassword?", async (req, res) => {
   }
 });
 
+authRouter.post("/approveVolunteer/:email?", async (req, res) => {
+  const { firstName } = req.query;
+
+  try {
+    const response = await authService.sendVolunteerApprovedEmail(
+      req.params.email,
+      firstName as string,
+    );
+    if (response) {
+      res.status(204).send();
+    }
+  } catch (error) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
 export default authRouter;

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -314,6 +314,45 @@ class AuthService implements IAuthService {
     }
   }
 
+
+  async sendVolunteerApprovedEmail(
+    email: string,
+    firstName: string,
+  ): Promise<boolean> {
+    if (!this.emailService) {
+      const errorMessage =
+        "Attempted to call sendVolunteerApprovedEmail but this instance of AuthService does not have an EmailService instance";
+      Logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    try {
+      const emailBody = `
+      <html>
+      ${emailHeader}
+      <body>
+        <h2 style="font-weight: 700; font-size: 16px; line-height: 22px; color: #171717">Hi ${firstName},</h2>
+        <p>Welcome to the Community Fridge KW volunteer team! We are excited to have you on board. Your account status is APPROVED. 
+        You can now access our volunteer shifts and begin signing up for shifts here.<br /><br />
+        If you’re on Facebook, consider joining our CFKW Volunteers group! This is a great way to stay in the loop and also connect 
+        with fellow volunteers. We encourage you to look for the posts highlighted under the “Featured” section for critical 
+        announcements like hamper deliveries, as well as instructions to sign up for a fridge check in and/or food rescue.<br /><br />
+        In the meantime, if you have any questions, please reach out at communityfridge@uwblueprint.org.
+        </p>
+       ${emailFooter}
+      </body>
+    </html>
+      `;
+
+      this.emailService.sendEmail(email, "APPROVED: Volunteer Account Status", emailBody);
+      return true;
+    } catch (error) {
+      Logger.error(
+        `Failed to generate admin email for new volunteer sign up for volunteer with email ${email}`,
+      );
+      return false;
+    }
+  }
+
   async isAuthorizedByRole(
     accessToken: string,
     roles: Set<Role>,

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -314,7 +314,6 @@ class AuthService implements IAuthService {
     }
   }
 
-
   async sendVolunteerApprovedEmail(
     email: string,
     firstName: string,
@@ -343,7 +342,11 @@ class AuthService implements IAuthService {
     </html>
       `;
 
-      this.emailService.sendEmail(email, "APPROVED: Volunteer Account Status", emailBody);
+      this.emailService.sendEmail(
+        email,
+        "APPROVED: Volunteer Account Status",
+        emailBody,
+      );
       return true;
     } catch (error) {
       Logger.error(

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -63,7 +63,10 @@ interface IAuthService {
    * @param firstName of volunteer
    * @throws Error if unable to send email
    */
-  sendVolunteerApprovedEmail(email: string, firstName: string): Promise<boolean>;
+  sendVolunteerApprovedEmail(
+    email: string,
+    firstName: string,
+  ): Promise<boolean>;
 
   /**
    * Determine if the provided access token is valid and authorized for at least

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -58,6 +58,14 @@ interface IAuthService {
   sendAdminVolunteerSignUpEmail(email: string, fullName: string): Promise<void>;
 
   /**
+   * Sends an email to a volunteer when their status is approved
+   * @param email email of volunteer that has approved status
+   * @param firstName of volunteer
+   * @throws Error if unable to send email
+   */
+  sendVolunteerApprovedEmail(email: string, firstName: string): Promise<boolean>;
+
+  /**
    * Determine if the provided access token is valid and authorized for at least
    * one of the specified roles
    * @param accessToken user's access token

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -150,6 +150,22 @@ const confirmPasswordReset = async (
   }
 };
 
+const sendVolunteerApprovedEmail = async (
+  email: string,
+  firstName: string,
+): Promise<boolean> => {
+  try {
+    await baseAPIClient.post(
+      `/auth/approveVolunteer/${email}?firstName=${firstName}`,
+      {},
+      { withCredentials: true },
+    );
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export default {
   confirmEmailVerification,
   verifyPasswordResetCode,
@@ -160,4 +176,5 @@ export default {
   register,
   resetPassword,
   refresh,
+  sendVolunteerApprovedEmail,
 };

--- a/frontend/src/components/pages/UserManagement/index.tsx
+++ b/frontend/src/components/pages/UserManagement/index.tsx
@@ -18,6 +18,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import React from "react";
+import AuthAPIClient from "../../../APIClients/AuthAPIClient";
 
 import DonorAPIClient from "../../../APIClients/DonorAPIClient";
 import UserAPIClient from "../../../APIClients/UserAPIClient";
@@ -55,6 +56,7 @@ const UserManagementPage = (): JSX.Element => {
       mergedUsers.push({
         userId: volunteer.userId,
         id: volunteer.id,
+        firstName: volunteer.firstName,
         pointOfContact: `${volunteer.firstName} ${volunteer.lastName}`,
         company: "",
         email: volunteer.email,
@@ -68,6 +70,7 @@ const UserManagementPage = (): JSX.Element => {
       mergedUsers.push({
         userId: donor.userId,
         id: donor.id,
+        firstName: donor.firstName,
         pointOfContact: `${donor.firstName} ${donor.lastName}`,
         company: donor.businessName,
         email: donor.email,
@@ -138,6 +141,7 @@ const UserManagementPage = (): JSX.Element => {
         }
         return u;
       });
+      await AuthAPIClient.sendVolunteerApprovedEmail(user.email, user.firstName);
       setUsers(newUsers);
     }
   };

--- a/frontend/src/components/pages/UserManagement/types.ts
+++ b/frontend/src/components/pages/UserManagement/types.ts
@@ -3,6 +3,7 @@ import { Role, Status } from "../../../types/AuthTypes";
 export type UserMgmtTableRecord = {
   userId: string;
   id: string;
+  firstName: string;
   pointOfContact: string;
   company: string;
   email: string;


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Send Email to [Volunteer] when Admin approves their status](https://www.notion.so/uwblueprintexecs/Team-Hub-Phase-1-Enhancements-Phase-2-cf7744a5b04748059761c1649a61a463)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* `sendVolunteerApprovedEmail`  sends an info email to a volunteer when admin approves their status
    * Called when admin clicks `approve`

<img width="781" alt="image" src="https://user-images.githubusercontent.com/69697180/163686362-59c359bc-122f-4d8d-b07e-9ade9c8ef9fb.png">


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a new volunteer with pending status
2. Sign into admin and click approve on that volunteer (at `/user-management`)
3. Check your inbox for the volunteer email




## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
