### PR TITLE
feat: volunteer cancel fridge checkin emails

### DIFF
--- a/backend/typescript/services/interfaces/checkInService.ts
+++ b/backend/typescript/services/interfaces/checkInService.ts
@@ -21,11 +21,25 @@ interface ICheckInService {
   /**
    * Generate a confirmation email with check-in shift information for volunteer who signed up for the shift
    * @param volunteerId of volunteer who signed up for shift
-   * @param checkIn object that contains check-in donation information
+   * @param checkIn object that contains check-in information
    * @param isAdmin boolean for if the email is to be sent to an admin or volunteer
    * @throws Error if unable to send email
    */
   sendVolunteerCheckInSignUpConfirmationEmail(
+    volunteerId: string,
+    checkIn: CheckInDTO,
+    isAdmin: boolean,
+  ): Promise<void>;
+
+  /**
+   *
+   * Generate a confirmation email when a volunteer cancels a check-in shift
+   * @param volunteerId of volunteer who cancelled the shift
+   * @param checkIn object that contains the check-in information
+   * @param isAdmin boolean for if the email is to be sent to an admin or volunteer
+   * @throws Error if unable to send email
+   */
+  sendVolunteerCancelCheckInEmail(
     volunteerId: string,
     checkIn: CheckInDTO,
     isAdmin: boolean,


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Email sent to [Admin] and [Volunteer] when volunteer cancels check-in shift](https://www.notion.so/uwblueprintexecs/Email-sent-to-Volunteer-and-Admin-when-volunteer-cancels-Fridge-Check-In-Shift-e288bd676e9144c19649d1d3e9503fb5)
To volunteer:
![Screen Shot 2022-04-16 at 5 43 22 PM](https://user-images.githubusercontent.com/19617248/163692262-c0e04678-06eb-446f-90a4-a9eb69dcac9b.png)
To admin:
![Screen Shot 2022-04-16 at 5 43 55 PM](https://user-images.githubusercontent.com/19617248/163692263-e7dbd23d-1738-46c8-92fa-41c1fca3b50f.png)

## Implementation description. How did you make this change?
* When a volunteer cancels a check-in shift, a confirmation is sent to themselves and to admin.


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Sign up for checkins as volunteer, cancel the shift
2. Confirm you see email
3. Confirm `communityfridgekw@uwblueprint.org` receives admin email




## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s) 
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
