### PR TITLE
feat: send food rescue cancellation emails to admin and volunteer

### DIFF
--- a/backend/typescript/services/interfaces/schedulingService.ts
+++ b/backend/typescript/services/interfaces/schedulingService.ts
@@ -156,7 +156,7 @@ interface ISchedulingService {
    *
    * Generate a confirmation email when a volunteer cancels a food rescue shift
    * @param volunteerId of volunteer who cancelled the shift
-   * @param scheduling object that contains the check-in information
+   * @param scheduling object that contains the food rescue information
    * @param isAdmin boolean for if the email is to be sent to an admin or volunteer
    * @throws Error if unable to send email
    */

--- a/backend/typescript/services/interfaces/schedulingService.ts
+++ b/backend/typescript/services/interfaces/schedulingService.ts
@@ -151,6 +151,20 @@ interface ISchedulingService {
     current_date: string,
     role: string,
   ): Promise<void>;
+
+  /**
+   *
+   * Generate a confirmation email when a volunteer cancels a food rescue shift
+   * @param volunteerId of volunteer who cancelled the shift
+   * @param scheduling object that contains the check-in information
+   * @param isAdmin boolean for if the email is to be sent to an admin or volunteer
+   * @throws Error if unable to send email
+   */
+  sendFoodRescueCancellationEmail(
+    volunteerId: string,
+    scheduling: SchedulingDTO,
+    isAdmin: boolean,
+  ): Promise<void>;
 }
 
 export default ISchedulingService;

--- a/frontend/src/components/pages/UserManagement/index.tsx
+++ b/frontend/src/components/pages/UserManagement/index.tsx
@@ -18,8 +18,8 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import React from "react";
-import AuthAPIClient from "../../../APIClients/AuthAPIClient";
 
+import AuthAPIClient from "../../../APIClients/AuthAPIClient";
 import DonorAPIClient from "../../../APIClients/DonorAPIClient";
 import UserAPIClient from "../../../APIClients/UserAPIClient";
 import VolunteerAPIClient from "../../../APIClients/VolunteerAPIClient";
@@ -141,7 +141,10 @@ const UserManagementPage = (): JSX.Element => {
         }
         return u;
       });
-      await AuthAPIClient.sendVolunteerApprovedEmail(user.email, user.firstName);
+      await AuthAPIClient.sendVolunteerApprovedEmail(
+        user.email,
+        user.firstName,
+      );
       setUsers(newUsers);
     }
   };


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Email sent to Admin and Volunteer when Volunteer Cancels Food Rescue Shift](https://www.notion.so/uwblueprintexecs/Email-sent-to-Admin-and-Volunteer-when-Volunteer-Cancels-Food-Rescue-Shift-cc23eea1871041428f438f8c12cd2f86)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Send email when update to schedule is made


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as a volunteer
2. Sign up for a food rescue shift (confirmation email should be sent to admin - communityfridgekw@uwblueprint.org and volunteer)
3. Cancel the shift (cancellation email should be sent to admin - communityfridgekw@uwblueprint.org and volunteer)

Cancellation email to volunteer looks as follows:
<img width="1110" alt="Screen Shot 2022-04-16 at 7 12 09 PM" src="https://user-images.githubusercontent.com/37950626/163693959-356d4cfe-be00-471a-8f5e-9e1b8d99c60c.png">

Cancellation email to admin looks as follows:
<img width="1121" alt="Screen Shot 2022-04-16 at 7 57 18 PM" src="https://user-images.githubusercontent.com/37950626/163694763-a322ebdc-9ab0-42a1-8747-a37e45f689e7.png">


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
