### PR TITLE
fix: change icons functions to get date string

### DIFF
--- a/frontend/src/components/pages/Scheduling/SelectDateTime.tsx
+++ b/frontend/src/components/pages/Scheduling/SelectDateTime.tsx
@@ -139,7 +139,10 @@ const SelectDateTime = ({
     const iconsPerTimeSlot = [0, 0, 0, 0, 0] as number[];
     schedules.forEach((schedule) => {
       if (schedule) {
-        if (new Date(schedule.startTime).getDate() === selectedDate.getDate()) {
+        if (
+          new Date(schedule.startTime).toDateString() ===
+          selectedDate.toDateString()
+        ) {
           if (schedule.dayPart === selectedDayPart) {
             const timeSlots = getTimeSlot(schedule.dayPart);
             if (timeSlots) {

--- a/frontend/src/components/pages/UserManagement/index.tsx
+++ b/frontend/src/components/pages/UserManagement/index.tsx
@@ -18,8 +18,8 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import React from "react";
-import AuthAPIClient from "../../../APIClients/AuthAPIClient";
 
+import AuthAPIClient from "../../../APIClients/AuthAPIClient";
 import DonorAPIClient from "../../../APIClients/DonorAPIClient";
 import UserAPIClient from "../../../APIClients/UserAPIClient";
 import VolunteerAPIClient from "../../../APIClients/VolunteerAPIClient";
@@ -141,7 +141,10 @@ const UserManagementPage = (): JSX.Element => {
         }
         return u;
       });
-      await AuthAPIClient.sendVolunteerApprovedEmail(user.email, user.firstName);
+      await AuthAPIClient.sendVolunteerApprovedEmail(
+        user.email,
+        user.firstName,
+      );
       setUsers(newUsers);
     }
   };


### PR DESCRIPTION
## Brief description. What is this change? 
### [Donor icon shows on time slot even when no donation is booked for then](https://www.notion.so/uwblueprintexecs/Donor-icon-shows-on-time-slot-even-when-no-donation-is-booked-for-then-f2d4fca810314e808d2c84c4b0e9e5db)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* In functions where we count # of icons to show, use `toDateString` instead of `getDate`

<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as a donor
2. Schedule a donation on a certain day (e.g Weekly April 20)
3. Schedule a new donation, and on the Schedule Date Time step, make sure when you are choosing the time slot, the icon on April 20 shows 1 icon as necessary, and May 20, June 20, etc are empty/don't show icons)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s) 
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
