### PR TITLE
fix: remove volunteerId when donor edits donation to not need volunteer

### DIFF
--- a/frontend/src/components/pages/Scheduling/VolunteerInformation.tsx
+++ b/frontend/src/components/pages/Scheduling/VolunteerInformation.tsx
@@ -41,6 +41,7 @@ const VolunteerInformation = ({
     frequency,
     volunteerNeeded,
     volunteerTime,
+    volunteerId,
     pickupLocation,
     isPickup,
     notes,
@@ -165,11 +166,13 @@ const VolunteerInformation = ({
     const editedFields = {
       volunteerNeeded,
       volunteerTime: volunteerNeeded ? volunteerTime : null,
+      volunteerId: volunteerNeeded ? volunteerId : null,
       pickupLocation: volunteerNeeded && isPickup ? pickupLocation : null,
       isPickup: volunteerNeeded ? isPickup : null,
       notes,
       startTime,
     };
+
     const res = isOneTimeEvent
       ? await SchedulingAPIClient.updateSchedule(id, editedFields)
       : await SchedulingAPIClient.updateSchedulesByRecurringDonationId(


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Remove volunteerId when [Donor] edits donation to not need volunteer](https://www.notion.so/uwblueprintexecs/Remove-volunteerId-when-Donor-edits-donation-to-not-need-volunteer-d010f538b3024841b5e25af5f07ebca2)
Previously, when a donor edits a donation to no longer need a volunteer, we weren't setting `volunteerId` to null meaning if they required a volunteer again, the volunteer would be auto-assigned. This removes the volunteer if the donor no longer requires one.


<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
Set `volunteerId` to `null` if the edited fields no longer has `volunteerNeeded`.

Correct payload:
![image](https://user-images.githubusercontent.com/19617248/164131765-ae86568a-0212-402b-a5f5-36986b50b14a.png)



<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a donation that requires a volunteer
2. Sign up for donation as volunteer, verify you see it in volunteer dashboard
3. Log back in as donor and remove volunteer needed on donation
4. Verify the shift is gone in the volunteer dashboard




## Checklist
- [x] My PR name is descriptive and in imperative tense
- [X] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s) 
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [X] The appropriate tests if necessary have been written
