### PR TITLE
fix: set volunteerId to null when volunteering as admin

### DIFF
--- a/frontend/src/components/pages/AdminDashboard/components/CheckInInfoCard.tsx
+++ b/frontend/src/components/pages/AdminDashboard/components/CheckInInfoCard.tsx
@@ -102,6 +102,7 @@ const CheckInInfoCard = ({
       currentCheckIn.id,
       {
         isAdmin: true,
+        volunteerId: null,
       },
     );
 

--- a/frontend/src/components/pages/VolunteerScheduling/CheckIns.tsx
+++ b/frontend/src/components/pages/VolunteerScheduling/CheckIns.tsx
@@ -30,7 +30,7 @@ const CheckIns = ({
         await CheckInAPIClient.getAllCheckIns()
       ).map((checkin) => ({ ...checkin, type: ShiftType.CHECKIN }));
       const needVolunteerCheckIns = checkInResponse.filter(
-        (checkin) => !checkin.volunteerId,
+        (checkin) => !checkin.volunteerId && !checkin.isAdmin,
       );
       setCheckIns(needVolunteerCheckIns);
     };


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
Remove the volunteer assigned to a checkin when admin volunteers for it. Also filter the checkins for ones that aren't volunteers and also not admin. 
