### PR TITLE
fix: page scrolling in volunteer shift sign up flow

### DIFF
--- a/frontend/src/components/pages/VolunteerScheduling/index.tsx
+++ b/frontend/src/components/pages/VolunteerScheduling/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import { NavigationProps, Step, useStep } from "react-hooks-helper";
 
 import VolunteerContext from "../../../contexts/VolunteerContext";
@@ -46,6 +46,10 @@ const VolunteerScheduling = () => {
     initialStep: 0,
   });
   const { id } = step;
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [id]);
 
   switch (id) {
     case "shifts tab":


### PR DESCRIPTION
## Brief description. What is this change? 

In volunteer sign up flow, the page wasnt being scrolled back to top but now it is.


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Volunteer for a shift and make sure page scrolls to top when you proceed to the next step in the flow




## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
