### PR TITLE
fix: show checkin end time for volunteer details

### DIFF
--- a/frontend/src/components/pages/VolunteerScheduling/ConfirmShiftDetails.tsx
+++ b/frontend/src/components/pages/VolunteerScheduling/ConfirmShiftDetails.tsx
@@ -228,7 +228,9 @@ const ConfirmShiftDetails = ({
         <Text textStyle="mobileBody">
           {shift.type === ShiftType.SCHEDULING
             ? volunteerTimeLocal(shift.volunteerTime)
-            : startAndEndTimeLocal(shift.startDate)}
+            : `${startAndEndTimeLocal(shift.startDate)}-${startAndEndTimeLocal(
+                shift.endDate,
+              )}`}
         </Text>
         {shift.type === ShiftType.SCHEDULING && (
           <>

--- a/frontend/src/components/pages/VolunteerScheduling/ConfirmShiftDetails.tsx
+++ b/frontend/src/components/pages/VolunteerScheduling/ConfirmShiftDetails.tsx
@@ -134,11 +134,11 @@ const ConfirmShiftDetails = ({
   };
 
   const startAndEndTimeLocal = (date: string) => {
-    return date ? format(new Date(date), "h:mm aa") : "";
+    return date ? format(new Date(date), "h:mmaa") : "";
   };
 
   const volunteerTimeLocal = (date: string | null) => {
-    return date ? format(parse(date, "HH:mm", new Date()), "h:mm a") : "";
+    return date ? format(parse(date, "HH:mm", new Date()), "h:mma") : "";
   };
 
   return (


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Show Volunteer Time Range for Fridge Checkin Details](https://www.notion.so/uwblueprintexecs/Show-Full-Volunteer-Time-Range-for-Fridge-CheckIn-details-1dbc3de077d94934bbb4afa7162e0a7f)
Show the full start time and end time for checkin details when a volunteer signs up/view details.

<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
![Screen Shot 2022-04-21 at 9 11 00 PM](https://user-images.githubusercontent.com/19617248/164577296-bd53048b-7e42-4c25-a569-7c4dfb9395a7.png)



<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Volunteer Dashboard > View Details for Checkins

