### PR TITLE
fix: add color for today in custom css sheet

### DIFF
--- a/frontend/src/components/pages/Scheduling/selectDateTime.css
+++ b/frontend/src/components/pages/Scheduling/selectDateTime.css
@@ -25,7 +25,7 @@
 
 .rmdp-day.rmdp-today span {
   color: #000 !important;
-  background-color: transparent !important;
+  background-color: #ffe5f9 !important;
 }
 
 .rmdp-day.rmdp-selected span, .rmdp-day.rmdp-selected.rmdp-today span, .rmdp-day.rmdp-range.start span, .rmdp-day.rmdp-range.end span {


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Emphasize current day on calendar picker](https://www.notion.so/uwblueprintexecs/Emphasize-current-day-on-calendar-picker-9c0ae4f09ae24faa86f4c5ba7b138c92)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Update css to highlight current day in calendars
<img width="316" alt="image" src="https://user-images.githubusercontent.com/69697180/165151886-8016fa4a-c694-48a3-a1e6-38dfca0192cc.png">
<img width="585" alt="image" src="https://user-images.githubusercontent.com/69697180/165152024-c75e740d-cf8d-482f-825e-11c16979f355.png">
<img width="313" alt="image" src="https://user-images.githubusercontent.com/69697180/165151795-324ec39a-ccb9-4e66-be52-26528ed8c059.png">

<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.




## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s) 
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] The appropriate tests if necessary have been written
