### PR TITLE
fix: only have screening details for volunteers

### DIFF
--- a/frontend/src/components/auth/Signup/CreateAccount.tsx
+++ b/frontend/src/components/auth/Signup/CreateAccount.tsx
@@ -83,9 +83,14 @@ const CreateAccount = ({
         <Text as="span" textStyle="mobileBodyBold">
           My Account
         </Text>{" "}
-        section of the platform. Please note there will be a few screening
-        questions on the following pages, and your account will need to be
-        accepted by CFKW Admin before you are able to sign up for shifts.
+        section of the platform.
+        {role === Role.VOLUNTEER && (
+          <Text>
+            Please note there will be a few screening questions on the following
+            pages, and your account will need to be accepted by CFKW Admin
+            before you are able to sign up for shifts.
+          </Text>
+        )}
       </Text>
 
       <FormControl mt="2rem" isRequired>

--- a/frontend/src/components/common/FridgeCheckInDescription.tsx
+++ b/frontend/src/components/common/FridgeCheckInDescription.tsx
@@ -1,4 +1,3 @@
-import { EditIcon } from "@chakra-ui/icons";
 import { Box, Button, Link, Text } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";

--- a/frontend/src/components/common/FridgeFoodRescueDescription.tsx
+++ b/frontend/src/components/common/FridgeFoodRescueDescription.tsx
@@ -1,4 +1,3 @@
-import { EditIcon } from "@chakra-ui/icons";
 import { Box, Button, Link, Text } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";

--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -8,7 +8,6 @@ import {
   FormLabel,
   HStack,
   IconButton,
-  Img,
   Input,
   Spacer,
   Spinner,
@@ -22,7 +21,6 @@ import { useHistory } from "react-router-dom";
 import AuthAPIClient from "../../APIClients/AuthAPIClient";
 import DonorAPIClient from "../../APIClients/DonorAPIClient";
 import UserAPIClient from "../../APIClients/UserAPIClient";
-import pencilIcon from "../../assets/pencilIcon.svg";
 import { AUTHENTICATED_USER_KEY } from "../../constants/AuthConstants";
 import * as Routes from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";


### PR DESCRIPTION
## Brief description. What is this change? 
Only show the details for future screening questions if the `role` selected is for Volunteer.

**Volunteer**
![Screen Shot 2022-04-25 at 7 32 16 PM](https://user-images.githubusercontent.com/19617248/165191134-ae8dd2b6-b50a-4b17-aee3-f5f30b2f6a4a.png)



**Donor**
![Screen Shot 2022-04-25 at 7 32 21 PM](https://user-images.githubusercontent.com/19617248/165191146-984503a4-25b3-497e-bc60-830bbd8bdf65.png)




## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages follow conventional commits and are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s) 
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [X] The appropriate tests if necessary have been written
