### PR TITLE
fix: send volunteer pending email on signup

### DIFF
--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -95,6 +95,7 @@ authRouter.post("/register", registerRequestValidator, async (req, res) => {
           req.body.skillsQuestionResponse,
         ],
       );
+      await authService.sendEmailVolunteerPending(req.body.email);
     }
 
     res

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -50,11 +50,6 @@ class AuthService implements IAuthService {
         oobCode,
       );
       if (response.emailVerified) {
-        const user = await this.userService.getUserByEmail(response.email);
-
-        if (user.role === Role.VOLUNTEER) {
-          await this.sendEmailVolunteerPending(response.email);
-        }
         return true;
       }
       return false;


### PR DESCRIPTION
Instead of sending pending email to volunteer after they verify their email, we need to send email when they register.