### PR TITLE
feat: resend email verification link for unverified users on login

### DIFF
--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -146,6 +146,24 @@ authRouter.post(
   },
 );
 
+authRouter.get("/isEmailVerified/:email", async (req, res) => {
+  try {
+    await authService.isEmailVerifiedByFirebase(req.params.email);
+    res.status(204).send();
+  } catch (error) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
+authRouter.post("/resendEmailVerification/:email", async (req, res) => {
+  try {
+    await authService.sendEmailVerificationLink(req.params.email);
+    res.status(204).send();
+  } catch (error) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
 /* Emails a password reset link to the user with the specified email */
 authRouter.post("/resetPassword/:email", async (req, res) => {
   try {

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -29,14 +29,18 @@ class AuthService implements IAuthService {
   }
 
   /* eslint-disable class-methods-use-this */
-  async generateToken(email: string, password: string): Promise<AuthDTO> {
+  async generateToken(
+    email: string,
+    password: string,
+  ): Promise<AuthDTO & { isEmailVerified: boolean }> {
     try {
       const token = await FirebaseRestClient.signInWithPassword(
         email,
         password,
       );
       const user = await this.userService.getUserByEmail(email);
-      return { ...token, ...user };
+      const isEmailVerified = await this.isEmailVerifiedByFirebase(email);
+      return { ...token, ...user, isEmailVerified };
     } catch (error) {
       Logger.error(`Failed to generate token for user with email ${email}`);
       throw error;
@@ -73,6 +77,16 @@ class AuthService implements IAuthService {
         return true;
       }
       return false;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async isEmailVerifiedByFirebase(email: string): Promise<boolean> {
+    try {
+      const firebaseUser = await firebaseAdmin.auth().getUserByEmail(email);
+
+      return firebaseUser.emailVerified;
     } catch (error) {
       return false;
     }

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -125,6 +125,8 @@ interface IAuthService {
    * @returns true if new password change is successful, false otherwise
    */
   confirmPasswordReset(newPassword: string, oobCode: string): Promise<boolean>;
+
+  isEmailVerifiedByFirebase(email: string): Promise<boolean>;
 }
 
 export default IAuthService;

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -16,8 +16,9 @@ const login = async (
       { email, password },
       { withCredentials: true },
     );
-    localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(data));
-
+    if (data.isEmailVerified) {
+      localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(data));
+    }
     return data;
   } catch (error) {
     return null;
@@ -136,6 +137,19 @@ const confirmEmailVerification = async (oobCode: string): Promise<boolean> => {
   }
 };
 
+const resendEmailVerification = async (email: string): Promise<boolean> => {
+  try {
+    await baseAPIClient.post(
+      `/auth/resendEmailVerification/${email}`,
+      {},
+      { withCredentials: true },
+    );
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 const verifyPasswordResetCode = async (oobCode: string): Promise<boolean> => {
   try {
     await baseAPIClient.post(
@@ -190,6 +204,7 @@ export default {
   loginWithGoogle,
   register,
   resetPassword,
+  resendEmailVerification,
   refresh,
   sendVolunteerApprovedEmail,
 };

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -28,6 +28,7 @@ const Login = (): React.ReactElement => {
     isIncorrectLoginCredentails,
     setIsIncorrectLoginCredentails,
   ] = React.useState(false);
+  const [isEmailVerified, setIsEmailVerified] = React.useState(true);
 
   const setVolunteerContext = async function getVolunteerUser(
     user: AuthenticatedUser,
@@ -58,9 +59,22 @@ const Login = (): React.ReactElement => {
     const user: AuthenticatedUser = await authAPIClient.login(email, password);
     if (user === null) {
       setIsIncorrectLoginCredentails(true);
+    } else if (!user.isEmailVerified) {
+      setIsEmailVerified(false);
+      setIsIncorrectLoginCredentails(false);
+    } else {
+      setAuthenticatedUser(user);
+      setVolunteerContext(user);
     }
-    setAuthenticatedUser(user);
-    setVolunteerContext(user);
+  };
+
+  const handleResendEmailVerificationEmail = async () => {
+    const isResendSuccessful = await authAPIClient.resendEmailVerification(
+      email,
+    );
+    if (isResendSuccessful) {
+      setIsEmailVerified(true);
+    }
   };
 
   if (authenticatedUser) {
@@ -119,6 +133,24 @@ const Login = (): React.ReactElement => {
           >
             An incorrect email address or password was entered. Please try
             again!
+          </Text>
+        )}
+        {!isEmailVerified && (
+          <Text
+            my="24px"
+            textStyle={["mobileSmall", "desktopSmall"]}
+            color="tomato.100"
+          >
+            Your account has not been verified. Please click{" "}
+            <Text
+              cursor="pointer"
+              as="span"
+              onClick={handleResendEmailVerificationEmail}
+              textDecoration="underline"
+            >
+              here
+            </Text>{" "}
+            to resend the verification email.
           </Text>
         )}
         <Box mt="2.5rem">

--- a/frontend/src/components/pages/Account.tsx
+++ b/frontend/src/components/pages/Account.tsx
@@ -101,14 +101,6 @@ const Account = (): JSX.Element => {
     phoneNumber: "",
   });
 
-  const navigateToDashboard = () => {
-    history.push(
-      authenticatedUser!.role === Role.ADMIN
-        ? Routes.ADMIN_CHECK_INS
-        : Routes.DASHBOARD_PAGE,
-    );
-  };
-
   const onResetPasswordClick = async () => {
     const success = await AuthAPIClient.logout(authenticatedUser?.id);
     if (success) {
@@ -216,6 +208,7 @@ const Account = (): JSX.Element => {
     // update authenticatedUser and local storage to reflect changes
     const user = {
       accessToken: authenticatedUser!.accessToken,
+      isEmailVerified: true,
       ...updatedUser,
     };
     setAuthenticatedUser(user);
@@ -228,7 +221,11 @@ const Account = (): JSX.Element => {
         keys[i] === "lastName" ||
         keys[i] === "phoneNumber"
       ) {
-        setLocalStorageObjProperty(AUTHENTICATED_USER_KEY, keys[i], values[i]);
+        setLocalStorageObjProperty(
+          AUTHENTICATED_USER_KEY,
+          keys[i],
+          values[i].toString(),
+        );
       }
     }
 

--- a/frontend/src/types/AuthTypes.ts
+++ b/frontend/src/types/AuthTypes.ts
@@ -19,6 +19,7 @@ export type AuthenticatedUser = {
   role: Role;
   accessToken: string;
   phoneNumber: string;
+  isEmailVerified: boolean;
 } | null;
 
 export type AuthenticatedDonor = {


### PR DESCRIPTION
## Brief description. What is this change? 
<!-- Please replace with your ticket's URL -->
### [Add Ability to Resend Email Verification](https://www.notion.so/uwblueprintexecs/Add-Ability-to-Resend-Verification-Email-8c60cae75d5242ff80c8bc246e7b870a)

Add login route protection such that if a user is not verified yet in Firebase, they can't access the platform. There's three cases now:
1) `User enters wrong password for email`  🚫  Error text for "An incorrect password was entered" will appear.
2) `User enters correct password and email but are not verified` 🚫  Error text to prompt them to resend email verification will appear.
3) `User enters correct password and email and is verified` ✅  Successful login

https://user-images.githubusercontent.com/19617248/165666791-2a91d75d-83ea-4147-b115-1bbec43bd884.mp4



<!-- Give a quick summary of the implementation details, provide design justifications if necessary, highlight any areas that you would like specific focus on -->
## Implementation description. How did you make this change?
* Return if the email is verified from the firebase user in the login response and only log in the user if this parameter is true. 
* If it's false but the actual login was successful (credentials), prompt to resend email verification.


<!-- What should the reviewer do to verify your changes? What setup is needed? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Sign up on the platform but don't click link in verify email
2. Try to log in with credentials
3. Verify you can resend verification email from firebase




